### PR TITLE
Migrate to Symfony 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "repositories": [
-       {
+        {
             "type": "composer",
             "url": "http://packagist.orocrm.com"
         }
@@ -22,20 +22,20 @@
         "ext-gd": "*",
         "ext-xml": "*",
         "ext-mysql": "*",
-        "symfony/symfony": "v2.3.6",
-        "doctrine/orm": "2.4.1",
-        "doctrine/doctrine-bundle": "1.2.0",
-        "doctrine/data-fixtures": "1.0.0",
-        "doctrine/doctrine-fixtures-bundle": "2.2.0",
-        "twig/extensions": "1.0.1",
-        "symfony/assetic-bundle": "2.3.0",
+
+        "symfony/symfony": "~2.4",
+        "doctrine/orm": "~2.2,>=2.2.3",
+        "doctrine/doctrine-bundle": "~1.2",
+        "twig/extensions": "~1.0",
+        "symfony/assetic-bundle": "~2.3",
+        "symfony/swiftmailer-bundle": "~2.3",
+        "symfony/monolog-bundle": "~2.4",
+        "sensio/distribution-bundle": "~2.3",
+        "sensio/framework-extra-bundle": "~3.0",
+        "sensio/generator-bundle": "~2.3",
+        "incenteev/composer-parameter-handler": "~2.0",
         "symfony/icu": "~1.1",
-        "symfony/swiftmailer-bundle": "2.3.5",
-        "symfony/monolog-bundle": "2.3.0",
-        "sensio/distribution-bundle": "2.3.4",
-        "sensio/framework-extra-bundle": "2.3.4",
-        "sensio/generator-bundle": "2.3.4",
-        "incenteev/composer-parameter-handler": "2.1.0",
+        "doctrine/doctrine-fixtures-bundle": "dev-master",
         "jms/job-queue-bundle": "1.0.0",
         "jms/serializer": "0.14.0",
         "jms/serializer-bundle": "0.13.0",
@@ -54,7 +54,7 @@
         "leafo/lessphp": "0.4.0",
         "genemu/form-bundle": "2.2.1",
         "zendframework/zend-mail": "2.1.6",
-        "a2lix/translation-form-bundle": "1.2",
+        "a2lix/translation-form-bundle": "2.*@dev",
         "mtdowling/cron-expression": "1.0.3",
         "jdare/clank-bundle": "0.1.6",
         "lexik/maintenance-bundle": "dev-master",
@@ -74,7 +74,7 @@
     },
     "autoload": {
         "psr-0": {
-              "Oro\\Bundle": "src/"
+            "Oro\\Bundle": "src/"
         }
     }
 }


### PR DESCRIPTION
This is necessary changes in composer.json to migrate to Symfony 2.4. However it seems that you are using specific version of phpunit ones that I've tried fallen with fatal error. So I can proceed with this issue if you will provide exact configuration to launch unit tests.
