### PR TITLE
Fix issue #70 Process  timeout during installation

### DIFF
--- a/src/Oro/Bundle/InstallerBundle/Command/PlatformUpdateCommand.php
+++ b/src/Oro/Bundle/InstallerBundle/Command/PlatformUpdateCommand.php
@@ -3,6 +3,7 @@
 namespace Oro\Bundle\InstallerBundle\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 
@@ -20,7 +21,9 @@ class PlatformUpdateCommand extends ContainerAwareCommand
                 'Execute platform application update commands and init platform assets.'
                 . ' Please make sure that application cache is up-to-date before run this command.'
                 . ' Use cache:clear if needed.'
-            );
+            )
+            ->addOption('process-timeout', null, InputOption::VALUE_OPTIONAL, 'Process timeout', 360)
+        ;
     }
 
     /**
@@ -34,18 +37,19 @@ class PlatformUpdateCommand extends ContainerAwareCommand
             $this->getApplication(),
             $this->getContainer()->get('oro_cache.oro_data_cache_manager')
         );
+        $timeout = $input->getOption('process-timeout');
         $commandExecutor
-            ->runCommand('oro:migration:load', ['--process-isolation' => true, '--process-timeout' => 300])
+            ->runCommand('oro:migration:load', ['--process-isolation' => true, '--process-timeout' => $timeout])
             ->runCommand('oro:entity-config:clear')
             ->runCommand('oro:entity-extend:clear')
-            ->runCommand('oro:workflow:definitions:load')
-            ->runCommand('oro:migration:data:load', ['--process-isolation' => true, '--process-timeout' => 300])
-            ->runCommand('oro:navigation:init', array('--process-isolation' => true))
-            ->runCommand('oro:assets:install', array('--exclude' => ['OroInstallerBundle']))
+            ->runCommand('oro:workflow:definitions:load', ['--process-timeout' => $timeout])
+            ->runCommand('oro:migration:data:load', ['--process-isolation' => true, '--process-timeout' => $timeout])
+            ->runCommand('oro:navigation:init', ['--process-isolation' => true, '--process-timeout' => $timeout])
+            ->runCommand('oro:assets:install', ['--exclude' => ['OroInstallerBundle'], '--process-timeout' => $timeout])
             ->runCommand('assetic:dump')
-            ->runCommand('fos:js-routing:dump', array('--target' => 'web/js/routes.js'))
+            ->runCommand('fos:js-routing:dump', ['--target' => 'web/js/routes.js', '--process-timeout' => $timeout])
             ->runCommand('oro:localization:dump')
             ->runCommand('oro:translation:dump')
-            ->runCommand('oro:requirejs:build', array('--ignore-errors' => true));
+            ->runCommand('oro:requirejs:build', ['--ignore-errors' => true, '--process-timeout' => $timeout]);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | y |
| New Feature? | n |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | n |
| Fixed Tickets | #70 |
| License | MIT |
| Doc PR |  |

This provides the ability to change timeout for Symfony Process component, useful for small servers when running oro:requirejs:build
 Sent using [Gush](https://github.com/gushphp/gush)
