### PR TITLE
Get constraints with the property path if it fails through fields name.

### DIFF
--- a/src/Oro/Bundle/FormBundle/Form/Extension/JsValidation/ConstraintsProvider.php
+++ b/src/Oro/Bundle/FormBundle/Form/Extension/JsValidation/ConstraintsProvider.php
@@ -81,6 +81,12 @@ class ConstraintsProvider
 
         if (isset($this->metadataConstraintsCache[$parentKey][$name])) {
             $result = $this->metadataConstraintsCache[$parentKey][$name]->constraints;
+        } else {
+            //If no metadata for the fields name, try getting it with the property path
+            $propertyPath = (string)$form->getPropertyPath();
+            if (isset($this->metadataConstraintsCache[$parentKey][$propertyPath])) {
+                $result = $this->metadataConstraintsCache[$parentKey][$propertyPath]->constraints;
+            }
         }
 
         return $result;


### PR DESCRIPTION
When no constraints are available with the field name, try using the property path.
