### PR TITLE
Label correction in messages.en.yml

### DIFF
--- a/src/Oro/Bundle/LocaleBundle/Resources/translations/messages.en.yml
+++ b/src/Oro/Bundle/LocaleBundle/Resources/translations/messages.en.yml
@@ -34,7 +34,7 @@ oro.locale:
                     fahrenheit: 'Fahrenheit'
                     celsius: 'Celsius'
             wind_speed_unit:
-                label: 'First Quarter Starts on'
+                label: 'Wind Speed Unit'
                 choices:
                     miles_per_hour: 'Miles per hour'
                     kilometers_per_hour: 'Kilometers per hour'


### PR DESCRIPTION
Please, replace wrong label "First Quarter Starts on" with "Wind Speed Unit".
