### PR TITLE
Fix error if magento product has null name

### DIFF
--- a/src/Oro/Bundle/BatchBundle/Step/StepExecutor.php
+++ b/src/Oro/Bundle/BatchBundle/Step/StepExecutor.php
@@ -150,6 +150,16 @@ class StepExecutor
                         continue;
                     }
 
+                    if (isset($readItem['items']) && count($readItem['items']) > 0) {
+                        $incrementItem = 0;
+                        foreach($readItem['items'] as $item) {
+                            if (empty($item['name'])){
+                                $readItem['items'][$incrementItem]['name'] = "Unknown";
+                            }
+                            $incrementItem++;
+                        }
+                    }
+
                 } catch (InvalidItemException $e) {
                     $this->handleStepExecutionWarning($this->reader, $e, $warningHandler);
 


### PR DESCRIPTION
PHP memory leak after magento sync found a product with null name. 

```
PHP Fatal error: Allowed memory size of 2147483648 bytes exhausted (tried to allocate 72 bytes) in /var/www/html/orocrm/vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php on line 587
```

```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry ‘OroCRM\Bundle\MagentoBundle\Entity\Customer-503′ for key ‘idx_entity’
Following orders were not imported: 100000806, 100000807, 100000808, 100000809, 100000810, 100000811, 100000812, 100000813, 100000814, 100000815, 100000816, 100000817, 100000818, 100000819, 100000820, 100000821, 100000822, 100000825, 100000826, 100000827, 100000828, 100000829, 100000830, 100000831, 100000832) [] []
[2014-11-05 22:37:07] batch.WARNING: The Oro\Bundle\IntegrationBundle\ImportExport\Writer\PersistentBatchWriter was unable to handle the following item: [] (REASON: An exception occurred while executing ‘INSERT INTO oro_search_item (entity, alias, record_id, title, changed, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)’ with params ["OroCRM\\Bundle\\MagentoBundle\\Entity\\Customer", "orocrm_magento_customer", 517, "XXXXXX XXXXXXX", 0, "2014-11-06 03:37:07", "2014-11-06 03:37:07"]:

SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry ‘OroCRM\Bundle\MagentoBundle\Entity\Customer-517′ for key ‘idx_entity’
Following orders were not imported: 100000833, 100000834, 100000835, 100000836, 100000837, 100000838, 100000839, 100000840, 100000841, 100000842, 100000843, 100000844, 100000845, 100000846, 100000847, 100000848, 100000849, 100000850, 100000851, 100000852, 100000853, 100000854, 100000855, 100000856, 100000857) [] []
```
