### PR TITLE
corrected italian regions/provinces

### DIFF
--- a/src/Oro/Bundle/AddressBundle/Resources/translations/entities.en.yml
+++ b/src/Oro/Bundle/AddressBundle/Resources/translations/entities.en.yml
@@ -2163,26 +2163,6 @@ region:
     IS-6: 'Norðurland eystra'
     IS-7: Austurland
     IS-8: Suðurland
-    IT-21: Piemonte
-    IT-23: 'Valle d''Aosta'
-    IT-25: Lombardia
-    IT-32: 'Trentino-Alto Adige'
-    IT-34: Veneto
-    IT-36: 'Friuli-Venezia Giulia'
-    IT-42: Liguria
-    IT-45: Emilia-Romagna
-    IT-52: Toscana
-    IT-55: Umbria
-    IT-57: Marche
-    IT-62: Lazio
-    IT-65: Abruzzo
-    IT-67: Molise
-    IT-72: Campania
-    IT-75: Puglia
-    IT-77: Basilicata
-    IT-78: Calabria
-    IT-82: Sicilia
-    IT-88: Sardegna
     IT-AG: Agrigento
     IT-AL: Alessandria
     IT-AN: Ancona
@@ -2233,7 +2213,8 @@ region:
     IT-LO: Lodi
     IT-LT: Latina
     IT-LU: Lucca
-    IT-MB: 'Monza e Brianza'
+    IT-MB: 'Monza e della Brianza'
+    IT-MC: Macerata
     IT-ME: Messina
     IT-MI: Milano
     IT-MN: Mantova
@@ -2268,7 +2249,6 @@ region:
     IT-RN: Rimini
     IT-RO: Rovigo
     IT-SA: Salerno
-    IT-SC: Macerata
     IT-SI: Siena
     IT-SO: Sondrio
     IT-SP: 'La Spezia'


### PR DESCRIPTION
Regions: 2 changes:
- 'Monza e Brianza' is really called: 'Monza e della Brianza'
- 'Macerata' had wrong key 'IT-SC' -> corrected to 'IT-MC'

I have removed all regions which should not at all be in this list.

In Italy, regions do exist, but they are never used in addresses and they should not be listed in "states".

I noticed they had a different numeric key so probably you know this but anyways
nobody in italy uses them (only as a pre-selection so to narrow down the list of available provinces in a region).
