### PR TITLE
Add check for empty request params before splitting

### DIFF
--- a/src/Oro/Bundle/EntityBundle/Resources/views/Entities/relation.html.twig
+++ b/src/Oro/Bundle/EntityBundle/Resources/views/Entities/relation.html.twig
@@ -4,8 +4,8 @@
 
     {% set gridParams = {
         '_parameters' : {
-            'data_in': app.request.get('added')|split(','),
-            'data_not_in': app.request.get('removed')|split(','),
+            'data_in': app.request.get('added') ? app.request.get('added')|split(',') : [],
+            'data_not_in': app.request.get('removed') ? app.request.get('removed')|split(',') : []
         },
         'class_name': entity_class,
         'field_name': field_name,


### PR DESCRIPTION
Fixes the issue with sorting and filtering of a datagrid for `oro_multiple_entity`. 

It's related to #194 and to [this request](https://github.com/orocrm/crm/issues/91#issuecomment-65087911)

@DimaSoroka the user @alsma-magecore recommended I should do this and as you can see I did. 

Let me know if I should do anything else related to this.

Thanks
