### PR TITLE
Bug:  It is possible to get an attachment which has a / character in it's coded string

### DIFF
--- a/src/Oro/Bundle/AttachmentBundle/Manager/AttachmentManager.php
+++ b/src/Oro/Bundle/AttachmentBundle/Manager/AttachmentManager.php
@@ -213,17 +213,20 @@ class AttachmentManager
         $type = 'get',
         $absolute = false
     ) {
-
-        $urlString = base64_encode(
-            implode(
-                '|',
-                [
-                    $parentClass,
-                    $fieldName,
-                    $parentId,
-                    $type,
-                    $entity->getOriginalFilename()
-                ]
+        $urlString = str_replace(
+            '/',
+            '_',
+            base64_encode(
+                implode(
+                    '|',
+                    [
+                        $parentClass,
+                        $fieldName,
+                        $parentId,
+                        $type,
+                        $entity->getOriginalFilename()
+                    ]
+                )
             )
         );
         return $this->router->generate(
@@ -250,7 +253,9 @@ class AttachmentManager
      */
     public function decodeAttachmentUrl($urlString)
     {
-        if (!($decodedString = base64_decode($urlString)) || count($result = explode('|', $decodedString)) < 5) {
+        if (!($decodedString = base64_decode(str_replace('_', '/', $urlString)))
+            || count($result = explode('|', $decodedString)) < 5
+        ) {
             throw new \LogicException('Input string is not correct attachment encoded parameters');
         }
 

--- a/src/Oro/Bundle/AttachmentBundle/Tests/Unit/Manager/AttachmentManagerTest.php
+++ b/src/Oro/Bundle/AttachmentBundle/Tests/Unit/Manager/AttachmentManagerTest.php
@@ -94,10 +94,12 @@ class AttachmentManagerTest extends \PHPUnit_Framework_TestCase
     {
         $this->attachment->setId(1);
         $this->attachment->setExtension('txt');
+        $this->attachment->setOriginalFilename('testFile.withForwardSlash?.txt');
         $fieldName = 'testField';
         $parentEntity = new TestClass();
-        $expectsString = 'T3JvXEJ1bmRsZVxBdHRhY2htZW50QnVuZGxlXFRlc3RzXFVuaXRcRml4dHVyZXNcVGVzdENsYXNzfHRlc3RGaW'.
-            'VsZHwxfGRvd25sb2FkfHRlc3RGaWxlLnR4dA==';
+        $expectsString = 'T3JvXEJ1bmRsZVxBdHRhY2htZW50QnVuZGxlXFRlc3RzXFVuaXRcRml4dHVyZXNcVGVzdENsYXNzfHRlc3RG'.
+            'aWVsZHwxfGRvd25sb2FkfHRlc3RGaWxlLndpdGhGb3J3YXJkU2xhc2g_LnR4dA==';
+                                                                  //^Underscore should replace / character
         $this->router->expects($this->once())
             ->method('generate')
             ->with(
@@ -119,10 +121,10 @@ class AttachmentManagerTest extends \PHPUnit_Framework_TestCase
                 'testField',
                 1,
                 'download',
-                'testFile.txt'
+                'testFile.withForwardSlash?.txt'
             ],
             $this->attachmentManager->decodeAttachmentUrl(
-                'T3JvXFRlc3RcVGVzdENsYXNzfHRlc3RGaWVsZHwxfGRvd25sb2FkfHRlc3RGaWxlLnR4dA=='
+                'T3JvXFRlc3RcVGVzdENsYXNzfHRlc3RGaWVsZHwxfGRvd25sb2FkfHRlc3RGaWxlLndpdGhGb3J3YXJkU2xhc2g/LnR4dA=='
             )
         );
     }


### PR DESCRIPTION
Fix:  String replace all / characters with non-base64 characters and revert on decode
    Includes Unit test update

fixes #203
