### PR TITLE
Italian mods

### DIFF
--- a/src/Oro/Bundle/AddressBundle/Migrations/Data/ORM/data/countries.yml
+++ b/src/Oro/Bundle/AddressBundle/Migrations/Data/ORM/data/countries.yml
@@ -6376,6 +6376,9 @@ IT:
         IT-MB:
             combinedCode: IT-MB
             code: MB
+        IT-MC:
+            combinedCode: IT-MC
+            code: MC
         IT-ME:
             combinedCode: IT-ME
             code: ME
@@ -6478,9 +6481,6 @@ IT:
         IT-SA:
             combinedCode: IT-SA
             code: SA
-        IT-SC:
-            combinedCode: IT-SC
-            code: SC
         IT-SI:
             combinedCode: IT-SI
             code: SI

--- a/src/Oro/Bundle/AddressBundle/Migrations/Data/ORM/data/countries.yml
+++ b/src/Oro/Bundle/AddressBundle/Migrations/Data/ORM/data/countries.yml
@@ -6223,66 +6223,6 @@ IT:
     iso2Code: IT
     iso3Code: ITA
     regions:
-        IT-21:
-            combinedCode: IT-21
-            code: '21'
-        IT-23:
-            combinedCode: IT-23
-            code: '23'
-        IT-25:
-            combinedCode: IT-25
-            code: '25'
-        IT-32:
-            combinedCode: IT-32
-            code: '32'
-        IT-34:
-            combinedCode: IT-34
-            code: '34'
-        IT-36:
-            combinedCode: IT-36
-            code: '36'
-        IT-42:
-            combinedCode: IT-42
-            code: '42'
-        IT-45:
-            combinedCode: IT-45
-            code: '45'
-        IT-52:
-            combinedCode: IT-52
-            code: '52'
-        IT-55:
-            combinedCode: IT-55
-            code: '55'
-        IT-57:
-            combinedCode: IT-57
-            code: '57'
-        IT-62:
-            combinedCode: IT-62
-            code: '62'
-        IT-65:
-            combinedCode: IT-65
-            code: '65'
-        IT-67:
-            combinedCode: IT-67
-            code: '67'
-        IT-72:
-            combinedCode: IT-72
-            code: '72'
-        IT-75:
-            combinedCode: IT-75
-            code: '75'
-        IT-77:
-            combinedCode: IT-77
-            code: '77'
-        IT-78:
-            combinedCode: IT-78
-            code: '78'
-        IT-82:
-            combinedCode: IT-82
-            code: '82'
-        IT-88:
-            combinedCode: IT-88
-            code: '88'
         IT-AG:
             combinedCode: IT-AG
             code: AG

--- a/src/Oro/Bundle/AddressBundle/Resources/translations/entities.en.yml
+++ b/src/Oro/Bundle/AddressBundle/Resources/translations/entities.en.yml
@@ -2213,7 +2213,7 @@ region:
     IT-LO: Lodi
     IT-LT: Latina
     IT-LU: Lucca
-    IT-MB: 'Monza e Brianza'
+    IT-MB: 'Monza e della Brianza'
     IT-ME: Messina
     IT-MI: Milano
     IT-MN: Mantova

--- a/src/Oro/Bundle/AddressBundle/Resources/translations/entities.en.yml
+++ b/src/Oro/Bundle/AddressBundle/Resources/translations/entities.en.yml
@@ -2214,6 +2214,7 @@ region:
     IT-LT: Latina
     IT-LU: Lucca
     IT-MB: 'Monza e della Brianza'
+    IT-MC: Macerata
     IT-ME: Messina
     IT-MI: Milano
     IT-MN: Mantova
@@ -2248,7 +2249,6 @@ region:
     IT-RN: Rimini
     IT-RO: Rovigo
     IT-SA: Salerno
-    IT-SC: Macerata
     IT-SI: Siena
     IT-SO: Sondrio
     IT-SP: 'La Spezia'

--- a/src/Oro/Bundle/AddressBundle/Resources/translations/entities.en.yml
+++ b/src/Oro/Bundle/AddressBundle/Resources/translations/entities.en.yml
@@ -2163,26 +2163,6 @@ region:
     IS-6: 'Norðurland eystra'
     IS-7: Austurland
     IS-8: Suðurland
-    IT-21: Piemonte
-    IT-23: 'Valle d''Aosta'
-    IT-25: Lombardia
-    IT-32: 'Trentino-Alto Adige'
-    IT-34: Veneto
-    IT-36: 'Friuli-Venezia Giulia'
-    IT-42: Liguria
-    IT-45: Emilia-Romagna
-    IT-52: Toscana
-    IT-55: Umbria
-    IT-57: Marche
-    IT-62: Lazio
-    IT-65: Abruzzo
-    IT-67: Molise
-    IT-72: Campania
-    IT-75: Puglia
-    IT-77: Basilicata
-    IT-78: Calabria
-    IT-82: Sicilia
-    IT-88: Sardegna
     IT-AG: Agrigento
     IT-AL: Alessandria
     IT-AN: Ancona


### PR DESCRIPTION
The problem: platform lists both regions and provinces in "state/province" field which is really confusing.
In Italy, regions do exist, but they are never used in addresses. We normally use it as a pre-selection to narrow down the list of provinces, but with autocomplete fields it is unnecessary.

So this PR tries to correct this by removing them completely.

Other small region changes:
  - 'Monza e Brianza' is really called: 'Monza e della Brianza'
  - 'Macerata' had wrong key 'IT-SC' -> corrected to 'IT-MC'

