### PR TITLE
BugFix: dropdownButton UI bundle macro

### DIFF
--- a/src/Oro/Bundle/UIBundle/Resources/views/macros.html.twig
+++ b/src/Oro/Bundle/UIBundle/Resources/views/macros.html.twig
@@ -223,7 +223,7 @@
         <ul class="dropdown-menu {{ parameters.aCss is defined? parameters.aCss : '' }}">
             {% if parameters.elements is defined and parameters.elements is not empty %}
                 {% for item in parameters.elements %}
-                    {{ _self.dropdownItem(parameters) }}
+                    {{ _self.dropdownItem(item) }}
                 {% endfor %}
             {% endif %}
             {% if parameters.html is defined and parameters.html is not empty %}


### PR DESCRIPTION
Fixes issue with dropdownButton UI bundle macro that caused twig exception when providing the elements key in passed parameters.  

This was due to the looped variable "item" not being passed to dropdownItem but instead the full "parameters" variable.