### PR TITLE
Fix grid caching data issue

### DIFF
--- a/src/Oro/Bundle/DataGridBundle/Resources/public/js/app/components/datagrid-component.js
+++ b/src/Oro/Bundle/DataGridBundle/Resources/public/js/app/components/datagrid-component.js
@@ -79,6 +79,7 @@ define(function (require) {
         processOptions: function (options) {
             options.$el = $(document.createDocumentFragment());
             options.gridName = options.gridName || options.metadata.options.gridName;
+            options.gridId = options.gridId || options.metadata.options.gridId;
             options.builders = options.builders || [];
             options.builders.push('orodatagrid/js/grid-views-builder');
             options.gridPromise = this.built.promise();
@@ -92,6 +93,7 @@ define(function (require) {
         initDataGrid: function (options) {
             this.$el = options.$el;
             this.gridName = options.gridName;
+            this.gridId = options.gridId;
             this.data = options.data;
             this.metadata = _.defaults(options.metadata, {
                 columns: [],
@@ -137,7 +139,7 @@ define(function (require) {
         build: function () {
             var options, collectionOptions, collection, collectionName, grid;
 
-            collectionName = this.gridName;
+            collectionName = this.gridId;
             collection = gridContentManager.get(collectionName);
             if (!collection) {
                 // otherwise, create collection from metadata

--- a/src/Oro/Bundle/DataGridBundle/Resources/views/macros.html.twig
+++ b/src/Oro/Bundle/DataGridBundle/Resources/views/macros.html.twig
@@ -22,6 +22,7 @@
         {% set gridId   = oro_datagrid_generate_element_id(datagrid) %}
         {% set options  = {
             el: '#' ~ gridId,
+            gridId: gridId,
             gridName: oro_datagrid_build_fullname(datagrid.name, datagrid.scope),
             builders: metaData.requireJSModules,
             metadata: metaData,


### PR DESCRIPTION
Fixes #223

The only question I had (which was also the reason I did not make this pull request before) was the reasoning behind the datagrid caching. The reasoning is unknown to me but thinking out loud right now I realize that this caching is useful only when you rerender the grid and the data (the collection) is fetched already. So it is safe to use the gridId instead of the gridName (which conflicts with other grids with the same name).

Thank you.