### PR TITLE
OroKernel collectBundles fix when bundles.yml empty

### DIFF
--- a/src/Oro/Bundle/DistributionBundle/OroKernel.php
+++ b/src/Oro/Bundle/DistributionBundle/OroKernel.php
@@ -134,9 +134,13 @@ abstract class OroKernel extends Kernel
         $exclusions = array();
         foreach ($files as $file) {
             $import  = Yaml::parse($file);
-            $bundles = array_merge($bundles, $this->getBundlesMapping($import['bundles']));
-            if (!empty($import['exclusions'])) {
-                $exclusions = array_merge($exclusions, $this->getBundlesMapping($import['exclusions']));
+            if (null !== $import){
+                if (null !== $import['bundles']){
+                    $bundles = array_merge($bundles, $this->getBundlesMapping($import['bundles']));
+                }
+                if (!empty($import['exclusions'])) {
+                    $exclusions = array_merge($exclusions, $this->getBundlesMapping($import['exclusions']));
+                }
             }
         }
 


### PR DESCRIPTION
When bundles.yml file empty or has no 'bundles:' node - need to filter it correctly. Just ignore such files content.