### PR TITLE
Bug: Datagrids return the wrong number of rows when paginating a complex joined query

### DIFF
--- a/src/Oro/Bundle/BatchBundle/ORM/QueryBuilder/CountQueryBuilderOptimizer.php
+++ b/src/Oro/Bundle/BatchBundle/ORM/QueryBuilder/CountQueryBuilderOptimizer.php
@@ -95,7 +95,7 @@ class CountQueryBuilderOptimizer
             $this->addJoins($qb, $parts);
         }
         if (!$parts['groupBy']) {
-            $fieldsToSelect[] = $this->getFieldFQN($this->idFieldName);
+            $fieldsToSelect[] = sprintf('DISTINCT %s', $this->getIdFieldFQN());
         }
 
         if ($parts['where']) {
@@ -106,6 +106,16 @@ class CountQueryBuilderOptimizer
         $this->qbTools->fixUnusedParameters($qb);
 
         return $qb;
+    }
+
+    /**
+     * Get Identifier field's fully qualified namespace
+     *
+     * @return string
+     */
+    public function getIdFieldFQN()
+    {
+        return $this->getFieldFQN($this->idFieldName);
     }
 
     /**

--- a/src/Oro/Bundle/BatchBundle/Tests/Functional/ORM/QueryBuilder/CountQueryBuilderOptimizerTest.php
+++ b/src/Oro/Bundle/BatchBundle/Tests/Functional/ORM/QueryBuilder/CountQueryBuilderOptimizerTest.php
@@ -42,7 +42,7 @@ class CountQueryBuilderOptimizerTest extends WebTestCase
                 'queryBuilder' => self::createQueryBuilder($em)
                     ->from('OroUserBundle:User', 'u')
                     ->select(array('u.id', 'u.username')),
-                'expectedDQL' => 'SELECT u.id FROM OroUserBundle:User u'
+                'expectedDQL' => 'SELECT DISTINCT u.id FROM OroUserBundle:User u'
             ),
             'group_test' => array(
                 'queryBuilder' => self::createQueryBuilder($em)
@@ -98,7 +98,7 @@ class CountQueryBuilderOptimizerTest extends WebTestCase
                     ->from('OroUserBundle:User', 'u')
                     ->leftJoin('OroUserBundle:UserApi', 'api')
                     ->select(array('u.id', 'u.username', 'api.apiKey')),
-                'expectedDQL' => 'SELECT u.id FROM OroUserBundle:User u',
+                'expectedDQL' => 'SELECT DISTINCT u.id FROM OroUserBundle:User u',
             ),
             'used_left_join' => array(
                 'queryBuilder' => self::createQueryBuilder($em)
@@ -107,7 +107,7 @@ class CountQueryBuilderOptimizerTest extends WebTestCase
                     ->select(array('u.id', 'u.username', 'api.apiKey as aKey'))
                     ->where('aKey = :test')
                     ->setParameter('test', 'test_api_key'),
-                'expectedDQL' => 'SELECT u.id FROM OroUserBundle:User u '
+                'expectedDQL' => 'SELECT DISTINCT u.id FROM OroUserBundle:User u '
                     . 'LEFT JOIN OroUserBundle:UserApi api '
                     . 'WHERE api.apiKey = :test',
             ),
@@ -117,7 +117,7 @@ class CountQueryBuilderOptimizerTest extends WebTestCase
                     ->innerJoin('OroOrganizationBundle:BusinessUnit', 'bu', Join::WITH, 'u.owner = bu.id')
                     ->leftJoin('OroUserBundle:UserApi', 'api')
                     ->select(array('u.id', 'u.username', 'api.apiKey as aKey')),
-                'expectedDQL' => 'SELECT u.id FROM OroUserBundle:User u '
+                'expectedDQL' => 'SELECT DISTINCT u.id FROM OroUserBundle:User u '
                     . 'INNER JOIN OroOrganizationBundle:BusinessUnit bu WITH u.owner = bu.id'
             ),
             'inner_with_2_left_group' => array(
@@ -164,7 +164,7 @@ class CountQueryBuilderOptimizerTest extends WebTestCase
                     ->leftJoin('u.apiKeys', 'api')
                     ->select(array('u.id', 'u.username', 'api.apiKey as aKey'))
                     ->where('gr.id > 10'),
-                'expectedDQL' => 'SELECT u.id FROM OroUserBundle:User u '
+                'expectedDQL' => 'SELECT DISTINCT u.id FROM OroUserBundle:User u '
                     . 'INNER JOIN u.owner bu '
                     . 'LEFT JOIN u.groups g '
                     . 'LEFT JOIN g.roles gr WITH api.apiKey = :test '
@@ -226,7 +226,7 @@ class CountQueryBuilderOptimizerTest extends WebTestCase
                     ->from('OroUserBundle:User', 'u')
                         ->select(array('u.id', 'u.username as login', 'api.apiKey as aKey'))
                         ->having('login LIKE :test'),
-                'expectedDQL'  => 'SELECT u.id FROM OroUserBundle:User u WHERE u.username LIKE :test'
+                'expectedDQL'  => 'SELECT DISTINCT u.id FROM OroUserBundle:User u WHERE u.username LIKE :test'
             ),
             'join_on_table_that_has_with_join_condition' => array(
                 'queryBuilder' => self::createQueryBuilder($em)
@@ -236,7 +236,7 @@ class CountQueryBuilderOptimizerTest extends WebTestCase
                         ->leftJoin('e.user', 'eu')
                         ->leftJoin('eu.owner', 'euo')
                         ->where('euo.name = :name'),
-                'expectedDQL'  => 'SELECT u.id FROM OroUserBundle:User u '
+                'expectedDQL'  => 'SELECT DISTINCT u.id FROM OroUserBundle:User u '
                     . 'LEFT JOIN OroUserBundle:Email e WITH e.user = u '
                     . 'LEFT JOIN e.user eu '
                     . 'LEFT JOIN eu.owner euo WHERE euo.name = :name'
@@ -249,7 +249,7 @@ class CountQueryBuilderOptimizerTest extends WebTestCase
                         ->leftJoin('e.user', 'eu')
                         ->leftJoin('OroUserBundle:Status', 's', Join::WITH, 's.user = eu')
                         ->where('s.status = :statusName'),
-                'expectedDQL'  => 'SELECT u.id FROM OroUserBundle:User u '
+                'expectedDQL'  => 'SELECT DISTINCT u.id FROM OroUserBundle:User u '
                     . 'LEFT JOIN OroUserBundle:Email e WITH e.user = u '
                     . 'LEFT JOIN OroUserBundle:Status s WITH s.user = e.user '
                     . 'WHERE s.status = :statusName'

--- a/src/Oro/Bundle/DataGridBundle/Extension/Pager/Orm/Pager.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Pager/Orm/Pager.php
@@ -4,6 +4,7 @@ namespace Oro\Bundle\DataGridBundle\Extension\Pager\Orm;
 
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
+
 use Oro\Bundle\BatchBundle\ORM\Query\QueryCountCalculator;
 use Oro\Bundle\BatchBundle\ORM\QueryBuilder\CountQueryBuilderOptimizer;
 use Oro\Bundle\DataGridBundle\Extension\Pager\PagerInterface;
@@ -138,18 +139,16 @@ class Pager extends AbstractPager implements PagerInterface
 
         /** @var QueryBuilder $query */
         $query = $this->getQueryBuilder();
+        if (count($this->getParameters()) > 0) {
+            $query->setParameters($this->getParameters());
+        }
         $countQb = $this->countQueryBuilderOptimizer->getCountQueryBuilder($this->getQueryBuilder());
 
         $query->setFirstResult(null);
         $query->setMaxResults(null);
 
-
-        if (count($this->getParameters()) > 0) {
-            $query->setParameters($this->getParameters());
-        }
-
         if (!$countQb->getDQLPart('groupBy')) {
-            $this->setPaginiationData($countQb);
+            $this->setPaginationData($countQb);
             foreach ($countQb->getQuery()->getResult() as $data) {
                 $inArray[] = current($data);
             }
@@ -159,7 +158,7 @@ class Pager extends AbstractPager implements PagerInterface
                 return;
             }
         }
-        $this->setPaginiationData($query);
+        $this->setPaginationData($query);
     }
 
     /**
@@ -250,7 +249,7 @@ class Pager extends AbstractPager implements PagerInterface
     /**
      * @param QueryBuilder $query
      */
-    private function setPaginiationData(QueryBuilder $query)
+    private function setPaginationData(QueryBuilder $query)
     {
         if (0 == $this->getPage() || 0 == $this->getMaxPerPage() || 0 == $this->getNbResults()) {
             $this->setLastPage(0);

--- a/src/Oro/Bundle/DataGridBundle/Extension/Pager/Orm/Pager.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Pager/Orm/Pager.php
@@ -139,10 +139,11 @@ class Pager extends AbstractPager implements PagerInterface
 
         /** @var QueryBuilder $query */
         $query = $this->getQueryBuilder();
+
         if (count($this->getParameters()) > 0) {
             $query->setParameters($this->getParameters());
         }
-        $countQb = $this->countQueryBuilderOptimizer->getCountQueryBuilder($this->getQueryBuilder());
+        $countQb = $this->countQueryBuilderOptimizer->getCountQueryBuilder($this->getQueryBuilder(), true);
 
         $query->setFirstResult(null);
         $query->setMaxResults(null);
@@ -249,7 +250,7 @@ class Pager extends AbstractPager implements PagerInterface
     /**
      * @param QueryBuilder $query
      */
-    private function setPaginationData(QueryBuilder $query)
+    protected function setPaginationData(QueryBuilder $query)
     {
         if (0 == $this->getPage() || 0 == $this->getMaxPerPage() || 0 == $this->getNbResults()) {
             $this->setLastPage(0);

--- a/src/Oro/Bundle/DataGridBundle/Extension/Pager/OrmPagerExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Pager/OrmPagerExtension.php
@@ -108,7 +108,7 @@ class OrmPagerExtension extends AbstractExtension
     public function getPriority()
     {
         // Pager should proceed closest to end of accepting chain
-        return -240;
+        return -250;
     }
 
     /**

--- a/src/Oro/Bundle/DataGridBundle/Extension/Sorter/OrmSorterExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Sorter/OrmSorterExtension.php
@@ -110,8 +110,8 @@ class OrmSorterExtension extends AbstractExtension
      */
     public function getPriority()
     {
-        // should visit after all extensions
-        return -250;
+        // should visit after all extensions other than paginator
+        return -240;
     }
 
     /**


### PR DESCRIPTION
Fix: For non grouped queries, paginate results using Doctrine Paginator methodolgy;
  Perform a Count query using DISTINCT keyword.
  Perform a Limit Subquery with DISTINCT to find all ids of the entity in from on the current page.
  Perform a WHERE IN query to get all results for the current page.

Includes updated test scenarios for CountQueryBuilderOptimizer.

I am happy to make any updates required, this works for all of the scenarios I have tested