### PR TITLE
Tag Manager Patch 

### DIFF
--- a/src/Oro/Bundle/TagBundle/Entity/TagManager.php
+++ b/src/Oro/Bundle/TagBundle/Entity/TagManager.php
@@ -163,12 +163,12 @@ class TagManager
                 );
             }
 
-            $taggingCollection = $this->getTaggingCollection($entity, $tag);
+            $taggingCollection = $this->getTaggingCollection ($entity, $tag);
 
             /** @var Tagging $tagging */
             foreach ($taggingCollection as $tagging) {
                 if ($owner = $tagging->getOwner()) {
-                    if ($this->getUser ()->getId() == $owner->getId()) {
+                    if ($this->securityContext->getToken ()->getUser ()->getId() == $owner->getId()) {
                         $entry['owner'] = true;
                     }
                 }


### PR DESCRIPTION
We don't need to retrieve all tagging objects. if the tag has too many tagging relations, the request takes a lot of time to complete