### PR TITLE
Extend exception in AssertAssembler to give more info

### DIFF
--- a/src/Oro/Bundle/WorkflowBundle/Model/AbstractAssembler.php
+++ b/src/Oro/Bundle/WorkflowBundle/Model/AbstractAssembler.php
@@ -90,7 +90,13 @@ abstract class AbstractAssembler
     {
         foreach ($requiredOptions as $optionName) {
             if (empty($options[$optionName])) {
-                throw new AssemblerException(sprintf('Option "%s" is required', $optionName));
+                if (isset($options['property_path'])) {
+                    $e = sprintf('Option "%s" is required for path "%s"', $optionName, $options['property_path']);
+                } else {
+                    $e = sprintf('Option "%s" is required', $optionName);
+                }
+
+                throw new AssemblerException($e);
             }
         }
     }


### PR DESCRIPTION
Added property_path from option to see where the option is missing

If property_path is always there, I will add it to unittest and and change exception with one line of code.