### PR TITLE
Require PHP 5.4

### DIFF
--- a/src/Oro/Bundle/CronBundle/composer.json
+++ b/src/Oro/Bundle/CronBundle/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/laboro/CronBundle",
     "license": "MIT",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "symfony/symfony": "2.3.*",
         "jms/job-queue-bundle": "dev-master",
         "mtdowling/cron-expression": "1.0.*",

--- a/src/Oro/Bundle/CronBundle/composer.json
+++ b/src/Oro/Bundle/CronBundle/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/laboro/CronBundle",
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.4.9",
         "symfony/symfony": "2.3.*",
         "jms/job-queue-bundle": "dev-master",
         "mtdowling/cron-expression": "1.0.*",


### PR DESCRIPTION
The CronBundle uses short-array syntax a lot, which isn't compatible with PHP 5.3