### PR TITLE
Fixed field local cache warm up in case of nested calls

### DIFF
--- a/src/Oro/Bundle/EntityConfigBundle/Config/ConfigModelManager.php
+++ b/src/Oro/Bundle/EntityConfigBundle/Config/ConfigModelManager.php
@@ -418,11 +418,11 @@ class ConfigModelManager
      */
     protected function ensureFieldLocalCacheWarmed($className)
     {
-        if (!isset($this->fieldLocalCache[$className])) {
-            $this->fieldLocalCache[$className] = [];
+        if (empty($this->fieldLocalCache[$className])) {
 
             $entityModel = $this->findEntityModel($className);
             if ($entityModel) {
+                $this->fieldLocalCache[$className] = [];
                 $fields = $entityModel->getFields();
                 foreach ($fields as $model) {
                     $this->fieldLocalCache[$className][$model->getFieldName()] = $model;

--- a/src/Oro/Bundle/EntityConfigBundle/Config/ConfigModelManager.php
+++ b/src/Oro/Bundle/EntityConfigBundle/Config/ConfigModelManager.php
@@ -419,8 +419,8 @@ class ConfigModelManager
     protected function ensureFieldLocalCacheWarmed($className)
     {
         if (empty($this->fieldLocalCache[$className])) {
-
             $entityModel = $this->findEntityModel($className);
+
             if ($entityModel) {
                 $this->fieldLocalCache[$className] = [];
                 $fields = $entityModel->getFields();


### PR DESCRIPTION
It seems like nested metadata load happens under certain conditions.

	1.	IndexMetadataBuilder tries to get field config
	2.	\Oro\Bundle\EntityConfigBundle\Config\ConfigModelManager::findFieldModel are called and it calls \Oro\Bundle\EntityConfigBundle\Config\ConfigModelManager::ensureFieldLocalCacheWarmed
	3.	ensureFieldLocalCacheWarmed calls \Oro\Bundle\EntityConfigBundle\Entity\EntityConfigModel::getFields
	4.	fields are loaded from DB
	5.	Doctrine unserializes field data and calls autoloader
	6.	autoloader calls getAllMetadata
	7.	that eventually lead to IndexMetadataBuilder tries to get config of the same field
	8.	findFieldModel are called again and it calls ensureFieldLocalCacheWarmed
	9.	BUT we are still in previous ensureFieldLocalCacheWarmed call!

In the second pass in ensureFieldLocalCacheWarmed $this->fieldLocalCache[$className] is already set. But it is an empty array because the previous call of ensureFieldLocalCacheWarmed not finished yet. So findFieldModel returns nothing and the exception are thrown.

This pull request does not fixes nested calls. But it prevents incorrect local field cache warm up.