### PR TITLE
Upgraded version of Nelmio API doc bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "knplabs/knp-menu-bundle": "2.0.0-alpha2",
         "friendsofsymfony/rest-bundle": "1.5.0-RC2",
         "friendsofsymfony/jsrouting-bundle": "1.5.0",
-        "nelmio/api-doc-bundle": "2.7.0",
+        "nelmio/api-doc-bundle": "2.9.*",
         "ass/xmlsecurity": "1.0.0",
         "besimple/soap": "0.2.2",
         "stof/doctrine-extensions-bundle": "1.1.0",


### PR DESCRIPTION
We require a feature in version 2.9 that allows us to segregate our domain-specific API documentation from the ORO API