### PR TITLE
Fix 'null' ID in route error caused when a PHP-based form validation …

### DIFF
--- a/src/Oro/Bundle/EntityExtendBundle/Form/Extension/DynamicFieldsExtension.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Form/Extension/DynamicFieldsExtension.php
@@ -260,21 +260,27 @@ class DynamicFieldsExtension extends AbstractTypeExtension
                 $title[] = FieldAccessor::getValue($entity, $fieldName);
             }
 
-            $result[] = [
-                'id'        => $entity->getId(),
-                'label'     => implode(' ', $title),
-                'link'      => $this->router->generate(
-                    'oro_entity_detailed',
-                    [
-                        'id'         => $entity->getId(),
-                        'entityName' => str_replace('\\', '_', $extendConfig->getId()->getClassName()),
-                        'fieldName'  => $extendConfig->getId()->getFieldName()
-                    ]
-                ),
-                'extraData' => $extraData,
-                'isDefault' => ($defaultEntity != null && $defaultEntity->getId() == $entity->getId())
-
-            ];
+            /**
+             * If using ExtendExtension with a form that only updates part of
+             * of the entity, we need to make sure an ID is present. An ID
+             * isn't present when a PHP-based Validation Constraint is fired.
+             */
+            if (null !== $entity->getId()) {
+                $result[] = [
+                    'id'        => $entity->getId(),
+                    'label'     => implode(' ', $title),
+                    'link'      => $this->router->generate(
+                        'oro_entity_detailed',
+                        [
+                            'id'         => $entity->getId(),
+                            'entityName' => str_replace('\\', '_', $extendConfig->getId()->getClassName()),
+                            'fieldName'  => $extendConfig->getId()->getFieldName()
+                        ]
+                    ),
+                    'extraData' => $extraData,
+                    'isDefault' => ($defaultEntity != null && $defaultEntity->getId() == $entity->getId())
+                ];
+            }
         }
 
         return $result;


### PR DESCRIPTION
…constraint is fired.

Use Case
 * Base Entity is extended using ExtendExtension to add collection (many-to-many)
 * User creates custom validation constraint to make sure the same item isn't added to `oro_collection` twice
 * Form is created adding only new ExtendExtension field
 * Form is submitted without triggering the validation and data is persisted to the database
 * Form is re-submitted and validation constraint fires
 * Observe `Parameter "id" for route "oro_entity_detailed" must match "[^/]++" ("" given) to generate a corresponding URL` Exception

Please reach out with comments or questions.
