### PR TITLE
Fix create extend field form after many-to-one relation

### DIFF
--- a/src/Oro/Bundle/EntityExtendBundle/Form/Type/FieldType.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Form/Type/FieldType.php
@@ -291,9 +291,4 @@ class FieldType extends AbstractType
 
         return true;
     }
-
-    protected function isManyToOneRelationAvailable()
-    {
-
-    }
 }

--- a/src/Oro/Bundle/EntityExtendBundle/Form/Type/FieldType.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Form/Type/FieldType.php
@@ -253,16 +253,16 @@ class FieldType extends AbstractType
         /** @var FieldConfigId $targetFieldId */
         $targetFieldId = $relation['target_field_id'];
 
-        if (!$relation['assign'] || !$targetFieldId) {
-            if (!$targetFieldId) {
-                return false;
-            }
+        if (!$targetFieldId) {
+            return false;
+        }
 
-            // additional check for revers relation of manyToOne field type
-            $targetEntityConfig = $extendProvider->getConfig($targetFieldId->getClassName());
-            if (false === (!$relation['assign']
+        // additional check for reverse relation of manyToOne field type
+        $targetEntityConfig = $extendProvider->getConfig($targetFieldId->getClassName());
+        if (!$relation['assign']) {
+            if (false === (
+                    !$relation['assign']
                     && !$fieldId
-                    && $targetFieldId
                     && $targetFieldId->getFieldType() == RelationTypeBase::MANY_TO_ONE
                     && $targetEntityConfig->get('relation')
                     && $targetEntityConfig->get('relation')[$relationKey]['assign']
@@ -270,6 +270,16 @@ class FieldType extends AbstractType
             ) {
                 return false;
             }
+        }
+
+        // case when entity A (e.g. Contact) has one-to-many
+        // (reverse many-to-one) relation
+        // from entity B (e.g. ContactAddress) but that relation has no FieldModel by design
+        if ($fieldId
+                && false == $relation['owner']
+                && $targetFieldId->getFieldType() == RelationTypeBase::MANY_TO_ONE
+        ) {
+            return false;
         }
 
         if ($fieldId
@@ -280,5 +290,10 @@ class FieldType extends AbstractType
         }
 
         return true;
+    }
+
+    protected function isManyToOneRelationAvailable()
+    {
+
     }
 }

--- a/src/Oro/Bundle/EntityExtendBundle/Tests/Functional/Form/FieldTypeTest.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Tests/Functional/Form/FieldTypeTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Oro\Bundle\EntityExtendBundle\Tests\Functional\Form;
+
+use Oro\Bundle\EntityExtendBundle\Form\Type\FieldType;
+use Oro\Bundle\TestFrameworkBundle\Test\WebTestCase;
+
+/**
+ * @outputBuffering enabled
+ * @dbIsolation
+ */
+class FieldTypeTest extends WebTestCase
+{
+    /** @var int */
+    protected $contactEntityId;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->initClient(
+            [],
+            array_merge($this->generateBasicAuthHeader(), ['HTTP_X-CSRF-Header' => 1]),
+            true
+        );
+
+        $this->contactEntityId = $this->getEntityIdFromGrid('Contact', 'OroCRMContactBundle');
+    }
+
+    /**
+     * Test should check original FieldType form produce exception
+     *
+     * This test should fail, once bug will be fixed
+     */
+    public function testCreateNewFieldFailed()
+    {
+        $this->markTestSkipped('The test is skiped as result of the fix, ' .
+            'for demonstration purposes, assumes that contact has many-to-one addresses extend field.');
+
+        // re-initialize client in order to manipulate with clear container
+        $this->initClient(
+            [],
+            array_merge($this->generateBasicAuthHeader(), ['HTTP_X-CSRF-Header' => 1]),
+            true
+        );
+
+        $container = $this->getContainer();
+        $fieldTypeService = 'oro_entity_extend.type.field';
+
+        $overriddenFormType = $this->replaceFieldTypeService(
+            $fieldTypeService,
+            new FieldType(
+                $container->get('oro_entity_config.config_manager'),
+                $container->get('translator.default'),
+                $container->get('oro_migration.db_id_name_generator')
+            )
+        );
+
+        $crawler = $this->client->request(
+            'GET',
+            $this->getUrl('oro_entityextend_field_create', ['id' => $this->contactEntityId])
+        );
+
+        $result = $this->client->getResponse();
+        $this->assertHtmlResponseStatusCodeEquals($result, 500);
+
+        $title = $crawler->filter('title')->text();
+        $this->assertEquals(
+            'A model for "OroCRM\Bundle\ContactBundle\Entity\ContactAddress::contact_addresses" ' .
+            'was not found (500 Internal Server Error)',
+            trim($title),
+            'Failed asserting that form returned an error.'
+        );
+
+        // return container to it's previous state
+        $this->replaceFieldTypeService($fieldTypeService, $overriddenFormType);
+    }
+
+    /**
+     * Test that ExtendFieldType override fixes the OroCRM bug
+     */
+    public function testCreateNewFieldFormWorks()
+    {
+        $contactEntityId = $this->getEntityIdFromGrid('Contact', 'OroCRMContactBundle');
+
+        $crawler = $this->client->request(
+            'GET',
+            $this->getUrl('oro_entityextend_field_create', ['id' => $contactEntityId])
+        );
+
+        $result = $this->client->getResponse();
+        $this->assertHtmlResponseStatusCodeEquals($result, 200);
+
+        $relationChoices = $crawler->filter('#oro_entity_extend_field_type_type > optgroup:nth-child(3) > option')
+            ->extract(['_text']);
+        $expectedRelationChoices = ['Many to many', 'Many to one', 'One to many'];
+        $this->assertEquals(
+            $expectedRelationChoices,
+            $relationChoices,
+            'Failed asserting that relation choices are correct'
+        );
+    }
+
+    /**
+     * Test that reverse relation still visible on the counter-part (e.g. ContactAddress)
+     */
+    public function testReverseFieldWorks()
+    {
+        $this->markTestSkipped(
+            'For demonstration purposes, assumes that contact has many-to-one addresses extend field.'
+        );
+
+        $contactAddressEntityId = $this->getEntityIdFromGrid('Contact', 'OroCRMContactBundle');
+
+        $crawler = $this->client->request(
+            'GET',
+            $this->getUrl('oro_entityextend_field_create', ['id' => $contactAddressEntityId])
+        );
+
+        $result = $this->client->getResponse();
+        $this->assertHtmlResponseStatusCodeEquals($result, 200);
+
+        $relationChoices = $crawler->filter('#oro_entity_extend_field_type_type > optgroup:nth-child(3) > option')
+            ->extract(['_text']);
+        $expectedRelationChoices = ['Many to many', 'Many to one', 'One to many', 'Reuse "Contact Address" of Contact'];
+        $this->assertEquals(
+            $expectedRelationChoices,
+            $relationChoices,
+            'Failed asserting that relation choices are correct'
+        );
+    }
+
+    /**
+     * Replace field type in FormRegistry
+     *
+     * @param string $serviceName
+     * @param mixed  $newService
+     *
+     * @return object returns old field type
+     */
+    protected function replaceFieldTypeService($serviceName, $newService)
+    {
+        $baseFieldType = $this->getContainer()->get($serviceName);
+
+        $this->getContainer()->set($serviceName, $newService);
+
+        return $baseFieldType;
+    }
+
+    /**
+     * @param string $entityName
+     * @param string $entityModule
+     *
+     * @return int
+     */
+    protected function getEntityIdFromGrid($entityName, $entityModule)
+    {
+        $gridName = 'entityconfig-grid';
+        $response = $this->client->requestGrid(['gridName' => $gridName]);
+        $result   = $this->getJsonResponseContent($response, 200);
+
+        return array_reduce(
+            $result['data'],
+            function ($carry, $item) use ($entityName, $entityModule) {
+                if ($item['entity_config_entity_name'] == $entityName &&
+                    $item['entity_config_module_name'] == $entityModule) {
+                    $carry = $item['id'];
+                }
+
+                return $carry;
+            },
+            null
+        );
+    }
+}

--- a/src/Oro/Bundle/EntityExtendBundle/Tests/Unit/Form/Type/FieldType/FieldTypeTest.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Tests/Unit/Form/Type/FieldType/FieldTypeTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Oro\Bundle\EntityExtendBundle\Tests\Unit\Form\Type\FieldType;
+
+use Oro\Bundle\EntityConfigBundle\Config\Id\FieldConfigId;
+use Oro\Bundle\EntityExtendBundle\Exception\RuntimeException;
+use Oro\Bundle\EntityExtendBundle\Tests\Unit\Form\Type\FieldTypeTest as BaseFieldTypeTest;
+
+/**
+ * Test to simulate bug with no fieldConfigModel exists for reverse relation
+ * This won't fail if the bug will be fixed, it's just to demonstrate
+ */
+class FieldTypeTest extends BaseFieldTypeTest
+{
+    protected $formOptions = [
+        'class_name' => 'OroCRM\Bundle\ContactBundle\Entity\Contact'
+    ];
+
+    /**
+     * Test that FieldType provide correct choices for field type select
+     * correct choices for owner side (e.g. Contact) - only standard o2m, m2o, m2m
+     */
+    public function testOneToManyRelation()
+    {
+        // mock expecting an exception, but it shouldn't happen
+        $this->prepareTestType($this->prepareOneToManyRelationsConfig(), true);
+
+        $form = $this->factory->create($this->type, null, $this->formOptions);
+
+        $this->assertSame(
+            $this->defaultFieldTypeChoices[self::RELATIONS_GROUP],
+            $form->offsetGet('type')->getConfig()->getOption('choices')[self::RELATIONS_GROUP],
+            'Failed: asserting that relation choices are the same'
+        );
+    }
+
+    /**
+     * Test that FieldType provide correct choices for field type select
+     * correct choices for reverse side (e.g. ConctactAddress) - standard + reverse
+     */
+    public function testManyToOneRelation()
+    {
+        // assert that reverse relation added on ContactAddress choices
+        $this->prepareTestType($this->prepareManyToOneRelationsConfig());
+        $form = $this->factory->create($this->type, null, $this->formOptions);
+
+        $typeName = 'oneToMany|OroCRM\Bundle\ContactBundle\Entity\Contact|' .
+            'OroCRM\Bundle\ContactBundle\Entity\ContactAddress|addresses||contact_addresses';
+
+        $expectedChoices = $this->defaultFieldTypeChoices;
+        $expectedChoices[self::RELATIONS_GROUP] = array_merge(
+            $expectedChoices[self::RELATIONS_GROUP],
+            [$typeName => 'oro.entity_extend.form.data_type.inverse_relation']
+        );
+        $this->assertSame(
+            $expectedChoices[self::RELATIONS_GROUP],
+            $form->offsetGet('type')->getConfig()->getOption('choices')[self::RELATIONS_GROUP]
+        );
+    }
+
+    /**
+     * @param array      $config
+     * @param bool|false $withException
+     */
+    protected function prepareTestType($config = [], $withException = false)
+    {
+        $entityConfigMock = $this->getMockBuilder('Oro\Bundle\EntityConfigBundle\Config\Config')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $entityConfigMock->expects($this->at(0))
+            ->method('is')
+            ->with('relation')
+            ->will($this->returnValue(true));
+        $entityConfigMock->expects($this->at(1))
+            ->method('get')
+            ->with('relation')
+            ->will($this->returnValue($config['relationConfig']));
+
+        if (!$withException) {
+            $entityConfigMock->expects($this->at(2))
+                ->method('get')
+                ->with('label')
+                ->will($this->returnValue('labelValue'));
+        }
+
+        $configProviderMock = $this->getMockBuilder('Oro\Bundle\EntityConfigBundle\Provider\ConfigProvider')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $configProviderMock->expects($this->any())
+            ->method('getConfig')
+            ->will($this->returnValue($entityConfigMock));
+
+        if ($withException) {
+            $configProviderMock->expects($this->any())
+                ->method('getConfigById')
+                ->with($config['relationTargetConfigFieldId'])
+                ->will($this->throwException(
+                    new RuntimeException(
+                        sprintf(
+                            'A model for "%s" was not found',
+                            'OroCRM\Bundle\ContactBundle\Entity\ContactAddress::contact_addresses'
+                        )
+                    )
+                ));
+        } else {
+            $configProviderMock->expects($this->any())
+                ->method('getConfigById')
+                ->with($config['relationTargetConfigFieldId'])
+                ->will($this->returnValue($entityConfigMock));
+        }
+
+        $this->configManagerMock->expects($this->any())
+            ->method('getProvider')
+            ->will($this->returnValue($configProviderMock));
+    }
+
+    /**
+     * from Contact to ContactAddress
+     *
+     * @return array
+     */
+    protected function prepareOneToManyRelationsConfig()
+    {
+        $relationConfigFieldId       = new FieldConfigId(
+            'extend',
+            'OroCRM\Bundle\ContactBundle\Entity\Contact',
+            'addresses',
+            'oneToMany'
+        );
+        $relationTargetConfigFieldId = new FieldConfigId(
+            'extend',
+            'OroCRM\Bundle\ContactBundle\Entity\ContactAddress',
+            'contact_addresses',
+            'manyToOne'
+        );
+
+        $relationConfig = [
+            'oneToMany|OroCRM\Bundle\ContactBundle\Entity\Contact|OroCRM\Bundle\ContactBundle\Entity\ContactAddress|addresses' => [
+                'assign'          => true,
+                'field_id'        => $relationConfigFieldId,
+                'owner'           => false,
+                'target_entity'   => 'OroCRM\Bundle\ContactBundle\Entity\ContactAddress',
+                'target_field_id' => $relationTargetConfigFieldId
+            ]
+        ];
+
+        return [
+            'relationTargetConfigFieldId' => $relationTargetConfigFieldId,
+            'relationConfig'              => $relationConfig
+        ];
+    }
+
+    /**
+     * from ContactAddress to Contact
+     *
+     * @return array
+     */
+    protected function prepareManyToOneRelationsConfig()
+    {
+        $relationConfigFieldId       = new FieldConfigId(
+            'extend',
+            'OroCRM\Bundle\ContactBundle\Entity\ContactAddress',
+            'contact_addresses',
+            'manyToOne'
+        );
+        $relationTargetConfigFieldId = new FieldConfigId(
+            'extend',
+            'OroCRM\Bundle\ContactBundle\Entity\Contact',
+            'addresses',
+            'oneToMany'
+        );
+
+        $relationConfig = [
+            'oneToMany|OroCRM\Bundle\ContactBundle\Entity\Contact|OroCRM\Bundle\ContactBundle\Entity\ContactAddress|addresses' => [
+                'assign'          => true,
+                'field_id'        => $relationConfigFieldId,
+                'owner'           => true,
+                'target_entity'   => 'OroCRM\Bundle\ContactBundle\Entity\Contact',
+                'target_field_id' => $relationTargetConfigFieldId
+            ]
+        ];
+
+        return [
+            'relationTargetConfigFieldId' => $relationTargetConfigFieldId,
+            'relationConfig'              => $relationConfig
+        ];
+    }
+}


### PR DESCRIPTION
STR:
- create extend one-to-many relation from Contact to ContactAddress
- update schema
- go to Contact entity and try to add another extend field

Expected: form to fill the entity field name and select type
Actual: 500 error "A model for "OroCRM\Bundle\ContactBundle\Entity\ContactAddress::contact_addresses" was not found (500 Internal Server Error)"

