### PR TITLE
fixing the value of `$isAssignGranted`

### DIFF
--- a/src/Oro/Bundle/OrganizationBundle/Form/Extension/OwnerFormExtension.php
+++ b/src/Oro/Bundle/OrganizationBundle/Form/Extension/OwnerFormExtension.php
@@ -151,7 +151,7 @@ class OwnerFormExtension extends AbstractTypeExtension
 
         $this->fieldName = $metadata->getOwnerFieldName();
 
-        $this->checkIsGranted('CREATE', 'entity:' . $dataClassName);
+        $this->checkIsGranted('ASSIGN', 'entity:' . $dataClassName);
         $defaultOwner = null;
 
         if ($metadata->isBasicLevelOwned() && $this->isAssignGranted) {


### PR DESCRIPTION
I was wondering how to hide the ownershipo dropdown for an entity with the access level set to `user`, so I asked in the forum: http://www.orocrm.com/forums/topic/how-do-i-remove-the-owner-dropdown

As explained, I set the assign permission to `none`. When I opened an entity item for update, the ownershio dropdown was gone. But when I created an entity item, I could still change set the owner.

I found out, that when creating an entity item, the `OwnerFormExtension` is checking, if the user has the `CREATE` permission. If this is true, the flag `$isAssignGranted` is set to true.

This makes no sense, as it should be possible to rescrict a user not being able to assign an entity item, even on creation. When the dropdown is removed, the item will be assigned to the user, just as someone would expect.

Is there any reason, which I might not see, why the original code is checking against the `CREATE` permission?