### PR TITLE
Made the Segment and Report entites extendable

### DIFF
--- a/src/Oro/Bundle/ReportBundle/Entity/Report.php
+++ b/src/Oro/Bundle/ReportBundle/Entity/Report.php
@@ -11,6 +11,8 @@ use Oro\Bundle\OrganizationBundle\Entity\Organization;
 use Oro\Bundle\QueryDesignerBundle\Model\AbstractQueryDesigner;
 use Oro\Bundle\QueryDesignerBundle\Model\GridQueryDesignerInterface;
 
+use Oro\Bundle\ReportBundle\Model\ExtendReport;
+
 /**
  * @ORM\Entity()
  * @ORM\Table(name="oro_report")
@@ -40,7 +42,7 @@ use Oro\Bundle\QueryDesignerBundle\Model\GridQueryDesignerInterface;
  *      }
  * )
  */
-class Report extends AbstractQueryDesigner implements GridQueryDesignerInterface
+class Report extends ExtendReport implements GridQueryDesignerInterface
 {
     const GRID_PREFIX = 'oro_report_table_';
 

--- a/src/Oro/Bundle/ReportBundle/Model/ExtendReport.php
+++ b/src/Oro/Bundle/ReportBundle/Model/ExtendReport.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Oro\Bundle\ReportBundle\Model;
+
+use Oro\Bundle\QueryDesignerBundle\Model\AbstractQueryDesigner;
+
+
+class ExtendReport extends AbstractQueryDesigner {
+    
+	/**
+     * Get the full name of an entity on which this report is based
+     *
+     * @return string
+     */
+    public function getEntity()
+    {
+        return $this->entity;
+    }
+
+    /**
+     * Set the full name of an entity on which this report is based
+     *
+     * @param string $entity
+     * @return Report
+     */
+    public function setEntity($entity)
+    {
+        $this->entity = $entity;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        return $this->definition;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefinition($definition)
+    {
+        $this->definition = $definition;
+
+        return $this;
+    }
+
+}

--- a/src/Oro/Bundle/SegmentBundle/Entity/Segment.php
+++ b/src/Oro/Bundle/SegmentBundle/Entity/Segment.php
@@ -11,6 +11,8 @@ use Oro\Bundle\EntityConfigBundle\Metadata\Annotation\Config;
 use Oro\Bundle\EntityConfigBundle\Metadata\Annotation\ConfigField;
 use Oro\Bundle\QueryDesignerBundle\Model\GridQueryDesignerInterface;
 
+use Oro\Bundle\SegmentBundle\Model\ExtendSegment;
+
 /**
  * Segment
  *
@@ -43,7 +45,7 @@ use Oro\Bundle\QueryDesignerBundle\Model\GridQueryDesignerInterface;
  *      }
  * )
  */
-class Segment extends AbstractQueryDesigner implements GridQueryDesignerInterface
+class Segment extends ExtendSegment implements GridQueryDesignerInterface
 {
     const GRID_PREFIX = 'oro_segment_grid_';
 

--- a/src/Oro/Bundle/SegmentBundle/Model/ExtendSegment.php
+++ b/src/Oro/Bundle/SegmentBundle/Model/ExtendSegment.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Oro\Bundle\SegmentBundle\Model;
+
+use Oro\Bundle\QueryDesignerBundle\Model\AbstractQueryDesigner;
+
+
+class ExtendSegment extends AbstractQueryDesigner {
+    
+	/**
+     * Get the full name of an entity on which this segment is based
+     *
+     * @return string
+     */
+    public function getEntity()
+    {
+        return $this->entity;
+    }
+
+    /**
+     * Set the full name of an entity on which this segment is based
+     *
+     * @param string $entity
+     * @return Segment
+     */
+    public function setEntity($entity)
+    {
+        $this->entity = $entity;
+
+        return $this;
+    }
+
+    /**
+     * Get this segment definition in YAML format
+     *
+     * @return string
+     */
+    public function getDefinition()
+    {
+        return $this->definition;
+    }
+
+    /**
+     * Set this segment definition in YAML format
+     *
+     * @param string $definition
+     * @return Segment
+     */
+    public function setDefinition($definition)
+    {
+        $this->definition = $definition;
+
+        return $this;
+    }
+
+}


### PR DESCRIPTION
Hello guys,

I added some comments on the forum and unfortunately I received no response. 
I want to add a few more fields to the Segment Entity and the Report Entity. I tried to make this two entities extendable via migrations and add field through data fixtures, but I could not make it work. 

I decided to try with a pull request because I saw that in the past you made other entities extendable when a user/client need it. 

I am using:
"oro/crm": "1.7",
"oro/platform": "1.7",
"oro/crm-enterprise": "1.9"

Thank you in advance and have a great weekend. 

Best Regards, 
Nelu Tihon