### PR TITLE
Added AttachmentType form type service

### DIFF
--- a/src/Oro/Bundle/AttachmentBundle/Controller/AttachmentController.php
+++ b/src/Oro/Bundle/AttachmentBundle/Controller/AttachmentController.php
@@ -11,7 +11,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
 use Oro\Bundle\SecurityBundle\Annotation\Acl;
 
-use Oro\Bundle\AttachmentBundle\Form\Type\AttachmentType;
 use Oro\Bundle\AttachmentBundle\Manager\AttachmentManager;
 use Oro\Bundle\AttachmentBundle\Entity\Attachment;
 
@@ -64,7 +63,7 @@ class AttachmentController extends Controller
         $attachmentEntity->setTarget($entity);
 
         $form       = $this->createForm(
-            new AttachmentType(),
+            $this->container->get('oro_attachment.form.type'),
             $attachmentEntity,
             ['parentEntityClass' => $entityClass, 'checkEmptyFile' => true]
         );
@@ -94,7 +93,7 @@ class AttachmentController extends Controller
     {
         $formAction = $this->getRequest()->getUri();
         $form       = $this->createForm(
-            new AttachmentType(),
+            $this->container->get('oro_attachment.form.type'),
             $attachment,
             [
                 'parentEntityClass' => ClassUtils::getRealClass($attachment->getTarget()),

--- a/src/Oro/Bundle/AttachmentBundle/Resources/config/form.yml
+++ b/src/Oro/Bundle/AttachmentBundle/Resources/config/form.yml
@@ -1,4 +1,5 @@
 parameters:
+    oro_attachment.form.type.class:                       Oro\Bundle\AttachmentBundle\Form\Type\AttachmentType
     oro_attachment.form.type.file_config.class:           Oro\Bundle\AttachmentBundle\Form\Type\FileConfigType
     oro_attachment.form.type.file.class:                  Oro\Bundle\AttachmentBundle\Form\Type\FileType
     oro_attachment.form.type.image.class:                 Oro\Bundle\AttachmentBundle\Form\Type\ImageType
@@ -7,6 +8,11 @@ parameters:
     oro_attachment.form.handler.attachment.class:         Oro\Bundle\AttachmentBundle\Form\Handler\AttachmentHandler
 
 services:
+    oro_attachment.form.type:
+        class: %oro_attachment.form.type.class%
+        tags:
+            - { name: form.type, alias: oro_attachment }
+
     oro_attachment.form.type.file_config:
         class: %oro_attachment.form.type.file_config.class%
         arguments:


### PR DESCRIPTION
- Added service with form type name alias
- Use service in controller

Useful if you need to overwrite the form type like I wanted to do. Can be merged to 1.8 too.