### PR TITLE
don't use empty array as IN() parameters in DQL

### DIFF
--- a/src/Oro/Bundle/CalendarBundle/Provider/UserCalendarProvider.php
+++ b/src/Oro/Bundle/CalendarBundle/Provider/UserCalendarProvider.php
@@ -38,6 +38,10 @@ class UserCalendarProvider implements CalendarProviderInterface
      */
     public function getCalendarDefaultValues($organizationId, $userId, $calendarId, array $calendarIds)
     {
+        if (empty($calendarIds)) {
+            return array();
+        }
+        
         $qb = $this->doctrineHelper->getEntityRepository('OroCalendarBundle:Calendar')
             ->createQueryBuilder('o')
             ->select('o, owner')


### PR DESCRIPTION
When the `UserCalendarProvider::getCalendarDefaultValues()` method is
called from the `CalendarManager::getCalendars()` method, an empty array
can be passed. However, using an empty array as a value of the DQL
`IN()` clause leads to a syntax error. Thus, we can prematurely return
here with an empty result.