### PR TITLE
fix not required on js type validation

### DIFF
--- a/src/Oro/Bundle/FormBundle/Resources/public/js/validator/type.js
+++ b/src/Oro/Bundle/FormBundle/Resources/public/js/validator/type.js
@@ -15,7 +15,7 @@ define(['underscore', 'orotranslation/js/translator'
             switch (param.type) {
                 case 'integer':
                     var valueNumber = Number(value).toFixed();
-                    return String(valueNumber) === value;
+                    return this.optional(element) || String(valueNumber) === value;
                 default:
                     return true;
             }


### PR DESCRIPTION
This fixes the js validation for integer type when it's not a required field.