### PR TITLE
Problem with process parameters in EntityPaginationBundle

### DIFF
--- a/src/Oro/Bundle/EntityPaginationBundle/Storage/StorageDataCollector.php
+++ b/src/Oro/Bundle/EntityPaginationBundle/Storage/StorageDataCollector.php
@@ -83,10 +83,18 @@ class StorageDataCollector
 
         $isDataCollected = false;
 
-        $gridNames = array_keys($request->query->get('grid', []));
+        $gridNames = array();
+        if ($request->query->get('grid')) {
+            $gridNames = array_keys($request->query->get('grid', []));
+        }
         foreach ($gridNames as $gridName) {
-            // datagrid manager automatically extracts all required parameters from request
-            $dataGrid = $this->datagridManager->getDatagridByRequestParams($gridName);
+            try {
+                // datagrid manager automatically extracts all required parameters from request
+                $dataGrid = $this->datagridManager->getDatagridByRequestParams($gridName);
+            } catch (\RuntimeException $e) {
+                continue;
+            }
+
             if (!$this->paginationManager->isDatagridApplicable($dataGrid)) {
                 continue;
             }


### PR DESCRIPTION
I found two problems. For example on http://demo.orocrm.com/.
If I went from accounts-grid I have
http://demo.orocrm.com/desktop/account/view/60?grid[accounts-grid]=i%3D1%26p%3D25%26s%255Bname%255D%3D-1%26v%3D__all__
1. But if I send http://demo.orocrm.com/desktop/account/view/60?grid I will have "Warning: array_keys() expects parameter 1 to be array, string given ." in dev mode. It don't reproduce on demo page because it isn't dev mode.

2. If i send http://demo.orocrm.com/desktop/account/view/60?grid[qweqeqwewqeqew] I will have other expection "A configuration for "qweqeqwewqeqew" datagrid was not found." because grid[qweqeqwewqeqew] not exist. It is call 500 error in demo page.

p. s. I think it needs some data validation there.
