### PR TITLE
Add helper methods to grid configuration

### DIFF
--- a/src/Oro/Bundle/DataGridBundle/Datagrid/Common/DatagridConfiguration.php
+++ b/src/Oro/Bundle/DataGridBundle/Datagrid/Common/DatagridConfiguration.php
@@ -2,8 +2,259 @@
 
 namespace Oro\Bundle\DataGridBundle\Datagrid\Common;
 
+use Doctrine\ORM\EntityRepository;
+
 use Oro\Bundle\DataGridBundle\Common\Object;
+use Oro\Bundle\EntityExtendBundle\Tools\ExtendHelper;
 
 class DatagridConfiguration extends Object
 {
+    const COLUMN_PATH = '[columns][%s]';
+    const SORTER_PATH = '[sorters][columns][%s]';
+    const FILTER_PATH = '[filters][columns][%s]';
+
+    /**
+     * @param string $name
+     * @param string $label
+     *
+     * @return DatagridConfiguration
+     */
+    public function updateLabel($name, $label)
+    {
+        if (empty($name)) {
+            throw new \BadMethodCallException('DatagridConfiguration::updateLabel: name should not be empty');
+        }
+
+        $this->offsetSetByPath(sprintf(self::COLUMN_PATH.'[label]', $name), $label);
+
+        return $this;
+    }
+
+    /**
+     * @param string      $name       column name
+     * @param array       $definition definition array as in datagrid.yml
+     * @param null|string $select     select part for the column
+     * @param array       $sorter     sorter definition
+     * @param array       $filter     filter definition
+     *
+     * @return DatagridConfiguration
+     */
+    public function addColumn($name, array $definition, $select = null, array $sorter = [], array $filter = [])
+    {
+        if (empty($name)) {
+            throw new \BadMethodCallException('DatagridConfiguration::addColumn: name should not be empty');
+        }
+
+        $this->offsetSetByPath(
+            sprintf(self::COLUMN_PATH, $name),
+            $definition
+        );
+
+        if (!is_null($select)) {
+            $this->addSelect($select);
+        }
+
+        if (!empty($sorter)) {
+            $this->addSorter($name, $sorter);
+        }
+
+        if (!empty($filter)) {
+            $this->addFilter($name, $filter);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $select
+     *
+     * @return DatagridConfiguration
+     */
+    public function addSelect($select)
+    {
+        if (empty($select)) {
+            throw new \BadMethodCallException('DatagridConfiguration::addSelect: select should not be empty');
+        }
+
+        $this->offsetAddToArrayByPath(
+            '[source][query][select]',
+            [$select]
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param string $type
+     * @param array  $definition
+     *
+     * @return DatagridConfiguration
+     */
+    public function joinTable($type, array $definition)
+    {
+        $this
+            ->offsetAddToArrayByPath(
+                sprintf('[source][query][join][%s]', $type),
+                [$definition]
+            );
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @param array  $definition
+     *
+     * @return DatagridConfiguration
+     */
+    public function addFilter($name, array $definition)
+    {
+        $this->offsetSetByPath(
+            sprintf(self::FILTER_PATH, $name),
+            $definition
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @param array  $definition
+     *
+     * @return DatagridConfiguration
+     */
+    public function addSorter($name, array $definition)
+    {
+        $this->offsetSetByPath(
+            sprintf(self::SORTER_PATH, $name),
+            $definition
+        );
+
+        return $this;
+    }
+
+    /**
+     * Remove column definition
+     * should remove sorters as well and optionally filters
+     *
+     * @param string $name         column name from grid definition
+     * @param bool   $removeFilter whether remove filter or not, true by default
+     *
+     * @return DatagridConfiguration
+     */
+    public function removeColumn($name, $removeFilter = true)
+    {
+        $this->offsetUnsetByPath(
+            sprintf(self::COLUMN_PATH, $name)
+        );
+
+        $this->removeSorter($name);
+        if ($removeFilter) {
+            $this->removeFilter($name);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $name column name
+     */
+    public function removeSorter($name)
+    {
+        $this->offsetUnsetByPath(
+            sprintf(self::SORTER_PATH, $name)
+        );
+    }
+
+    /**
+     * Remove filter definition
+     *
+     * @param string $name column name
+     *
+     * @return DatagridConfiguration
+     */
+    public function removeFilter($name)
+    {
+        $this->offsetUnsetByPath(
+            sprintf(self::FILTER_PATH, $name)
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param string $columnName column name
+     * @param string $dataName   property path of the field, e.g. entity.enum_field
+     * @param string $enumCode   enum code
+     * @param bool   $isMultiple allow to filter by several values
+     *
+     * @return DatagridConfiguration
+     */
+    public function addEnumFilter($columnName, $dataName, $enumCode, $isMultiple = false)
+    {
+        $this->addFilter(
+            $columnName,
+            [
+                'type'      => 'entity',
+                'data_name' => $dataName,
+                'options'   => [
+                    'field_options' => [
+                        'class'         => ExtendHelper::buildEnumValueClassName($enumCode),
+                        'property'      => 'name',
+                        'query_builder' => function (EntityRepository $entityRepository) {
+                            return $entityRepository->createQueryBuilder('c')
+                                ->orderBy('c.name', 'ASC');
+                        },
+                        'multiple'      => $isMultiple,
+                    ],
+                ],
+            ]
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param string      $name
+     * @param string      $label
+     * @param string      $templatePath
+     * @param null|string $select select part for the column
+     * @param array       $sorter sorter definition
+     * @param array       $filter filter definitio
+     *
+     * @return DatagridConfiguration
+     */
+    public function addTwigColumn($name, $label, $templatePath, $select = null, array $sorter = [], array $filter = [])
+    {
+        $this->addColumn(
+            $name,
+            [
+                'label'         => $label,
+                'type'          => 'twig',
+                'frontend_type' => 'html',
+                'template'      => $templatePath,
+            ],
+            $select,
+            $sorter,
+            $filter
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @param array  $options
+     *
+     * @return DatagridConfiguration
+     */
+    public function addMassAction($name, array $options)
+    {
+        $this->offsetSetByPath(
+            sprintf('[mass_actions][%s]', $name),
+            $options
+        );
+
+        return $this;
+    }
 }

--- a/src/Oro/Bundle/DataGridBundle/Tests/Unit/Datagrid/Common/DatagridConfigurationTest.php
+++ b/src/Oro/Bundle/DataGridBundle/Tests/Unit/Datagrid/Common/DatagridConfigurationTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Oro\Bundle\DataGridBundle\Tests\Unit\Datagrid\Common;
+
+use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
+
+class DatagridConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var DatagridConfiguration */
+    protected $configuration;
+
+    protected function setUp()
+    {
+        $this->configuration = DatagridConfiguration::create([]);
+    }
+
+    /**
+     * @dataProvider addColumnDataProvider
+     *
+     * @param array  $expected
+     * @param string $name
+     * @param string $select
+     * @param array  $definition
+     * @param array  $sorter
+     * @param array  $filter
+     */
+    public function testAddColumn(
+        $expected,
+        $name,
+        $definition,
+        $select = null,
+        $sorter = [],
+        $filter = []
+    ) {
+        $this->configuration->addColumn(
+            $name,
+            $definition,
+            $select,
+            $sorter,
+            $filter
+        );
+
+        $configArray = $this->configuration->toArray();
+        $this->assertEquals($expected, $configArray);
+    }
+
+    public function testExceptions()
+    {
+        $this->setExpectedException(
+            'BadMethodCallException',
+            'DatagridConfiguration::addColumn: name should not be empty'
+        );
+        $this->configuration->addColumn(null, []);
+
+        $this->setExpectedException(
+            'BadMethodCallException',
+            'DatagridConfiguration::updateLabel: name should not be empty'
+        );
+        $this->configuration->updateLabel(null, []);
+
+        $this->setExpectedException(
+            'BadMethodCallException',
+            'DatagridConfiguration::addSelect: select should not be empty'
+        );
+        $this->configuration->addSelect(null);
+    }
+
+    public function testUpdateLabel()
+    {
+        $this->configuration->updateLabel('testColumn', 'label1');
+
+        $configArray = $this->configuration->toArray();
+        $this->assertEquals(
+            ['columns' => ['testColumn' => ['label' => 'label1']]],
+            $configArray
+        );
+
+        $this->configuration->updateLabel('testColumn1', null);
+        $configArray = $this->configuration->toArray();
+        $this->assertEquals(
+            [
+                'columns' => [
+                    'testColumn'  => ['label' => 'label1'],
+                    'testColumn1' => ['label' => null],
+                ]
+            ],
+            $configArray
+        );
+
+        $this->configuration->updateLabel('testColumn', 'label2');
+        $configArray = $this->configuration->toArray();
+        $this->assertEquals(
+            [
+                'columns' => [
+                    'testColumn'  => ['label' => 'label2'],
+                    'testColumn1' => ['label' => null],
+                ]
+            ],
+            $configArray
+        );
+    }
+
+    public function testAddSelect()
+    {
+        $this->configuration->addSelect('testColumn');
+
+        $configArray = $this->configuration->toArray();
+        $this->assertEquals(
+            [
+                'source' => [
+                    'query' => ['select' => ['testColumn']],
+                ]
+            ],
+            $configArray
+        );
+    }
+
+    public function testJoinTable()
+    {
+        $this->configuration->joinTable('left', ['param' => 'value']);
+
+        $configArray = $this->configuration->toArray();
+        $this->assertEquals(
+            [
+                'source' => [
+                    'query' => ['join' => ['left' => [['param' => 'value']]]],
+                ]
+            ],
+            $configArray
+        );
+    }
+
+    public function testRemoveColumn()
+    {
+        $this->configuration->addColumn('testColumn', ['param' => 123], null, ['param' => 123], ['param' => 123]);
+
+        $configArray = $this->configuration->toArray();
+        $this->assertTrue(isset($configArray['columns']['testColumn']));
+
+        $this->configuration->removeColumn('testColumn');
+        $configArray = $this->configuration->toArray();
+
+        $this->assertEmpty($configArray['columns']);
+        $this->assertEmpty($configArray['sorters']['columns']);
+        $this->assertEmpty($configArray['filters']['columns']);
+    }
+
+    /**
+     * @return array
+     */
+    public function addColumnDataProvider()
+    {
+        return [
+            'all data supplied'         => [
+                'expected'   => [
+                    'source'  => [
+                        'query' => ['select' => ['entity.testColumn1',]],
+                    ],
+                    'columns' => ['testColumn1' => ['testParam1' => 'abc', 'testParam2' => 123,]],
+                    'sorters' => ['columns' => ['testColumn1' => ['data_name' => 'testColumn1']]],
+                    'filters' => ['columns' => ['testColumn1' => ['data_name' => 'testColumn1', 'type' => 'string']]],
+                ],
+                'name'       => 'testColumn1',
+                'definition' => ['testParam1' => 'abc', 'testParam2' => 123,],
+                'select'     => 'entity.testColumn1',
+                'sorter'     => ['data_name' => 'testColumn1'],
+                'filter'     => ['data_name' => 'testColumn1', 'type' => 'string'],
+            ],
+            'without sorter and filter' => [
+                'expected'   => [
+                    'source'  => [
+                        'query' => ['select' => ['entity.testColumn2',]],
+                    ],
+                    'columns' => ['testColumn2' => ['testParam1' => 'abc', 'testParam2' => 123,]],
+                ],
+                'name'       => 'testColumn2',
+                'definition' => ['testParam1' => 'abc', 'testParam2' => 123,],
+                'select'     => 'entity.testColumn2',
+            ],
+            'without select part'       => [
+                'expected'   => [
+                    'columns' => ['testColumn2' => ['testParam1' => 'abc', 'testParam2' => 123,]],
+                ],
+                'name'       => 'testColumn2',
+                'definition' => ['testParam1' => 'abc', 'testParam2' => 123,],
+            ],
+            'without sorter and select' => [
+                'expected'   => [
+                    'columns' => ['testColumn1' => ['testParam1' => 'abc', 'testParam2' => 123,]],
+                    'filters' => ['columns' => ['testColumn1' => ['data_name' => 'testColumn1', 'type' => 'string']]],
+                ],
+                'name'       => 'testColumn1',
+                'definition' => ['testParam1' => 'abc', 'testParam2' => 123,],
+                'select'     => null,
+                'sorter'     => [],
+                'filter'     => ['data_name' => 'testColumn1', 'type' => 'string'],
+            ],
+            'with empty definition'     => [
+                'expected'   => [
+                    'columns' => ['testColumn1' => []],
+                ],
+                'name'       => 'testColumn1',
+                'definition' => [],
+            ],
+        ];
+    }
+}

--- a/src/Oro/Bundle/EntityExtendBundle/Form/Type/DictionaryFilterType.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Form/Type/DictionaryFilterType.php
@@ -10,7 +10,6 @@ use Symfony\Component\Translation\TranslatorInterface;
 use Oro\Bundle\EntityExtendBundle\Provider\EnumValueProvider;
 use Oro\Bundle\EntityExtendBundle\Entity\AbstractEnumValue;
 use Oro\Bundle\EntityExtendBundle\Tools\ExtendHelper;
-use Oro\Bundle\EntityExtendBundle\Form\Type\AbstractMultiChoiceType;
 
 use Oro\Bundle\FilterBundle\Form\Type\Filter\ChoiceFilterType;
 
@@ -59,7 +58,7 @@ class DictionaryFilterType extends AbstractMultiChoiceType
 
                     if (empty($options['dictionary_code'])) {
                         throw new InvalidOptionsException(
-                            'Either "class" or "dictionary_code" must option must be set.'
+                            'Either "class" or "dictionary_code" option must be set.'
                         );
                     }
 


### PR DESCRIPTION
provide a way to manipulate grid configuration without knowing exact inner array structure
- add/remove column, filter, sorter
- add mass action
- update label
- join table
- add enum filter
- add twig column

cc @vsoroka @AlexandrDmitriev please let me know if you find it useful, or have any ideas about it, thanks.