### PR TITLE
Changed type of EmailTemplate

### DIFF
--- a/src/Oro/Bundle/EmailBundle/Workflow/Action/SendEmailTemplate.php
+++ b/src/Oro/Bundle/EmailBundle/Workflow/Action/SendEmailTemplate.php
@@ -126,7 +126,7 @@ class SendEmailTemplate extends AbstractSendEmail
         }
         $templateData = $this->renderer->compileMessage($emailTemplate, ['entity' => $entity]);
 
-        $type = $emailTemplate->getType() == 'txt' ? 'text/plain' : 'text/html';
+        $type = $emailTemplate->getType() == 'txt' ? 'text/plain' : 'html';
         list ($subjectRendered, $templateRendered) = $templateData;
 
         $emailModel->setSubject($subjectRendered);


### PR DESCRIPTION
Hello!
Using Workflows, I tried both of these configurations in `MyBundle/Resources/config/oro/workflow/my_workflow/transition_definition` : 

First : 
```
workflows:
    my_workflow:
        transition_definitions:
            trans1:
                ...
                post_actions:
                    - @send_email:
                        attribute: $email
                        from: $email_from
                        to: $email_to
                        subject: "Hello to you!"
                        body: "Hello world"
                        type: 'html'
```
and then, after having created an email template : 
```
workflows:
    my_workflow:
        transition_definitions:
            trans1:
                ...
                post_actions:
                    - @send_email_template:
                        from: $email_from
                        to: $email_to
                        template: 'template5'
                        entity: $people
```

In the first case, the email sent was correctly rendered in my email client (gmail).
But in the second case, I just received plain text, displaying all the uggly html tags. 

I managed to fix the bug.
In the first case, the class which is used is
`vendor/oro/platform/src/Oro/Bundle/EmailBundle/Workflow/Action/SendEmail.php`
and in the second case : 
`vendor/oro/platform/src/Oro/Bundle/EmailBundle/Workflow/Action/SendEmailTemplate.php`

At line 94 of the `SendEmail.php` class ([here](https://github.com/orocrm/platform/blob/master/src/Oro/Bundle/EmailBundle/Workflow/Action/SendEmail.php#L94)) , `$type` has the value `'html'` , and it works very well.
But at the equivalent place in `SendEmailTemplate.php`, i.e. [at line 134](https://github.com/orocrm/platform/blob/master/src/Oro/Bundle/EmailBundle/Workflow/Action/SendEmailTemplate.php#L134), `$type` has the value `'text/html'`, which doen't seems to render the email well, at least in Gmail. 
Logically speaking, I think that `$type` should be the same whether `SendEmail.php` or `SendEmailTemplate.php` is use, don't you think so?

If this pull request is accepted, it will be the very first one of my life, so it would be an emotional moment for me.
