### PR TITLE
Improved travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ php:
 env:
   - SYMFONY_VERSION=2.7.*
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 before_script:
   - phpenv config-rm xdebug.ini
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - SYMFONY_VERSION=2.7.*
 
 before_script:
+  - phpenv config-rm xdebug.ini
   - composer self-update
   - phpenv config-add travis.php.ini
   - travis_wait composer require symfony/symfony:${SYMFONY_VERSION} --prefer-source --update-no-dev

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,1 +1,1 @@
-memory_limit = 1024M
+memory_limit = 2G


### PR DESCRIPTION
As far tests is running without coverage then we can disable xdebug completely. This makes tests much faster.
Also enabled cache for composer and increased memory limit.