### PR TITLE
Added (optional) hhvm tests to travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ php:
 env:
   - SYMFONY_VERSION=2.7.*
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 before_script:
   - phpenv config-rm xdebug.ini
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - SYMFONY_VERSION=2.7.*
 
 before_script:
+  - phpenv config-rm xdebug.ini
   - composer self-update
   - phpenv config-add travis.php.ini
   - travis_wait composer require symfony/symfony:${SYMFONY_VERSION} --prefer-source --update-no-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,17 @@ sudo: false
 language: php
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: 7.0
+  fast_finish: true
 
 env:
   - SYMFONY_VERSION=2.7.*
@@ -15,12 +23,17 @@ cache:
     - $HOME/.composer/cache/files
 
 before_script:
-  - phpenv config-rm xdebug.ini
+  # PHP config
+  - if ! [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then phpenv config-rm xdebug.ini ; fi
+  - if ! [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then phpenv config-add travis.php.ini ; fi
+  # HHVM config
+  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then cp travis.hhvm.php.ini /etc/hhvm/php.ini  ; fi
+  - if [[ $TRAVIS_PHP_VERSION =~ ^hhvm ]]; then sudo service hhvm restart ; sleep 1 ; fi
+  # Composer
   - composer self-update
-  - phpenv config-add travis.php.ini
-  - travis_wait composer require symfony/symfony:${SYMFONY_VERSION} --prefer-source --update-no-dev
-  - travis_wait composer require squizlabs/php_codesniffer:~2 --prefer-source --update-no-dev
+  - travis_wait composer require symfony/symfony:${SYMFONY_VERSION} --prefer-dist --update-no-dev
+  - travis_wait composer require squizlabs/php_codesniffer:~2 --prefer-dist --update-no-dev
 
-script: 
+script:
   - phpunit
   - ./vendor/bin/phpcs ./src -p --encoding=utf-8 --extensions=php --standard=psr2

--- a/travis.hhvm.php.ini
+++ b/travis.hhvm.php.ini
@@ -1,0 +1,2 @@
+xdebug.enable = On
+hhvm.jit = false

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,1 +1,1 @@
-memory_limit = 1024M
+memory_limit = 2G


### PR DESCRIPTION
TravisCI tests for `hhvm` optionally so that `hhvm` support can be watched.

Sorry for that, but I'm sure I need to update this PR multiple times 