### PR TITLE
Fixed data migration bugs in address type/country

### DIFF
--- a/src/Oro/Bundle/AddressBundle/Migrations/Data/ORM/LoadAddressTypeData.php
+++ b/src/Oro/Bundle/AddressBundle/Migrations/Data/ORM/LoadAddressTypeData.php
@@ -54,8 +54,8 @@ class LoadAddressTypeData extends AbstractTranslatableEntityFixture
                 // save
                 $manager->persist($addressType);
             }
-        }
 
-        $manager->flush();
+            $manager->flush();
+        }
     }
 }

--- a/src/Oro/Bundle/AddressBundle/Migrations/Data/ORM/LoadCountryData.php
+++ b/src/Oro/Bundle/AddressBundle/Migrations/Data/ORM/LoadCountryData.php
@@ -190,9 +190,9 @@ class LoadCountryData extends AbstractTranslatableEntityFixture implements
                     }
                 }
             }
-        }
 
-        $manager->flush();
-        $manager->clear();
+            $manager->flush();
+            $manager->clear();
+        }
     }
 }


### PR DESCRIPTION
### Commit message

If you added another language you got an error during migration, because
country or type tried to be insert multiple times which caused an integrity
violation.

### More details
Step by step guide to reproduce the error
#### 1. Added Bundle extension
I added a bundle named *AddressBundle* in my namespace which uses the *OroAddressBundle* as parent.
```php
class AddressBundle extends Bundle
{
    public function getParent()
    {
        return 'OroAddressBundle';
    }
}
```
Added some more code like an extra migration, but it's not related to the error.

#### 2. Added translations
I added a translation file (*Resources/translations/Address/entities.de.yml*) with the following content:
```yaml
address_type:
    construction: Baustellen Adresse
    billing: Rechnungsadresse
```

#### 3. Run installation
If a run a clean setup on a clean database till this error:
>   [Doctrine\DBAL\Exception\UniqueConstraintViolationException]                                                                                                    
>   An exception occurred while executing 'INSERT INTO oro_dictionary_country (iso2_code, iso3_code, name) VALUES (?, ?, ?)' with params ["AD", "AND", "Andorra"]:  
  SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'AD' for key 'PRIMARY'     

#### Conclusion
It seems like my translation file with the `.de.yml` ending causes a second translation to be loaded (which is not happening without the file and looks like a correct behavior). 
Looking at the code:
The method `LoadCountryData::getCountry` checks if a country is already loaded, but there was no `$manager->flush()` yet, so the method always creates a new `$country`.

#### Solution
`$manager->flush()` after each translation. Afterwards, the `LoadCountryData::getCountry` will find a `$country` and the error doesn't occur.

Hope my description is good enough.