### PR TITLE
Fixed very important bug in BufferedQueryResultIterator

### DIFF
--- a/src/Oro/Bundle/BatchBundle/ORM/Query/BufferedQueryResultIterator.php
+++ b/src/Oro/Bundle/BatchBundle/ORM/Query/BufferedQueryResultIterator.php
@@ -239,6 +239,8 @@ class BufferedQueryResultIterator implements \Iterator, \Countable
         $this->position   = -1;
         $this->current    = null;
 
+        unset($this->rows);
+
         $this->next();
     }
 


### PR DESCRIPTION
Hello Oro team!

I found bug in BufferedQueryResultIterator.

For example, we have 100000 records for some query(in our case $query).
And we use this code:

``` php
$iterator = new BufferedQueryResultIterator($query);
$iterator->setBufferSize(100);
$iterator->rewind();
$iterator->rewind();
foreach ($iterator as $record) {
    echo $record->getId() . PHP_EOL;
}
```

This code displays the identifiers for 100100 items(without this fix of course).
Why 100100? Because first 100 rows(=buffer size) will be iterated twice.

Please include this fix for version 1.9.x!!!
