### PR TITLE
Remove pageSize strict type checking in DataGridBundle

### DIFF
--- a/src/Oro/Bundle/DataGridBundle/Resources/public/js/datagrid/page-size.js
+++ b/src/Oro/Bundle/DataGridBundle/Resources/public/js/datagrid/page-size.js
@@ -110,7 +110,7 @@ define([
                 _.bind(
                     function(item) {
                         return item.size === undefined ?
-                            this.collection.state.pageSize === item : this.collection.state.pageSize === item.size;
+                            this.collection.state.pageSize == item : this.collection.state.pageSize == item.size;
                     },
                     this
                 )


### PR DESCRIPTION
Fixes #395.

Non-default configurations for are provided as strings, and therefore fail the strict comparison. This leaves no elements in the currentSizeLabel array, and causes an exception that hangs the data grid display.