### PR TITLE
Remove unused parameter

### DIFF
--- a/src/Oro/Bundle/OrganizationBundle/Resources/config/services.yml
+++ b/src/Oro/Bundle/OrganizationBundle/Resources/config/services.yml
@@ -20,8 +20,6 @@ parameters:
     oro_organization.owner_deletion_manager.class:             Oro\Bundle\OrganizationBundle\Ownership\OwnerDeletionManager
     oro_organization.owner_assignment_checker.default.class:   Oro\Bundle\OrganizationBundle\Ownership\OwnerAssignmentChecker
 
-    oro_organization.autocomplete.organization.search_handler: Oro\Bundle\OrganizationBundle\Autocomplete\OrganizationSearchHandler
-
     oro_organization.entity_config_dumper.extension.class:     Oro\Bundle\OrganizationBundle\Tools\OwnershipEntityConfigDumperExtension
 
     oro_organization.event.business_unit_grid_listener.class:  Oro\Bundle\OrganizationBundle\Event\BusinessUnitGridListener


### PR DESCRIPTION
This line is never used in the application.

This one does the same and is used:
oro_organization.autocomplete.organization_search_handler.class: Oro\Bundle\OrganizationBundle\Autocomplete\OrganizationSearchHandler