### PR TITLE
Extract oro/property-access

### DIFF
--- a/src/Oro/Component/PropertyAccess/.gitignore
+++ b/src/Oro/Component/PropertyAccess/.gitignore
@@ -1,1 +1,4 @@
 *~
+/composer.lock
+/phpunit.xml
+/vendor/

--- a/src/Oro/Component/PropertyAccess/composer.json
+++ b/src/Oro/Component/PropertyAccess/composer.json
@@ -9,13 +9,12 @@
         "symfony/property-access": "~2.3"
     },
     "autoload": {
-        "psr-0": { "Oro\\Component\\PropertyAccess": "" }
+        "psr-4": { "Oro\\Component\\PropertyAccess\\": "" }
     },
-    "target-dir": "Oro/Component/PropertyAccess",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }

--- a/src/Oro/Component/PropertyAccess/phpunit.xml.dist
+++ b/src/Oro/Component/PropertyAccess/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="./vendor/autoload.php"
+        >
+
+    <testsuites>
+        <testsuite name="Property Access Test Suite">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">.</directory>
+            <exclude>
+                <directory>./vendor</directory>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
At the moment `oro/config` depends on classes from the property access component. In order to reference these classes, `oro/property-access` should be extracted into a subtree split and uploaded to Packagist.

I will submit a separate PR to incorporate these changes into the config component.