### PR TITLE
[Config] Fix dependencies

### DIFF
--- a/src/Oro/Component/Config/.gitignore
+++ b/src/Oro/Component/Config/.gitignore
@@ -1,1 +1,4 @@
 *~
+/composer.lock
+/phpunit.xml
+/vendor/

--- a/src/Oro/Component/Config/composer.json
+++ b/src/Oro/Component/Config/composer.json
@@ -8,16 +8,16 @@
         "php": ">=5.4.9",
         "symfony/config": "~2.1",
         "symfony/dependency-injection": "~2.1",
-        "symfony/yaml": "~2.1"
+        "symfony/yaml": "~2.1",
+        "oro/property-access": "1.x-dev"
     },
     "autoload": {
-        "psr-0": { "Oro\\Component\\Config": "" }
+        "psr-4": { "Oro\\Component\\Config\\": "" }
     },
-    "target-dir": "Oro/Component/Config",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }

--- a/src/Oro/Component/Config/phpunit.xml.dist
+++ b/src/Oro/Component/Config/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="./vendor/autoload.php"
+        >
+
+    <testsuites>
+        <testsuite name="Config Test Suite">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">.</directory>
+            <exclude>
+                <directory>./vendor</directory>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
**Dependencies:** #405 

At the moment `Oro\Component\Config\Resolver\SystemAwareResolver` does depend on `Oro\Component\PropertyAccess\PropertyAccessor`. However `oro/property-access` is not listed as dependency in `oro/config`. After applying this patch, all tests pass.