### PR TITLE
Added twig phone extension

### DIFF
--- a/src/Oro/Bundle/AddressBundle/DependencyInjection/OroAddressExtension.php
+++ b/src/Oro/Bundle/AddressBundle/DependencyInjection/OroAddressExtension.php
@@ -26,6 +26,7 @@ class OroAddressExtension extends Extension
         $loader->load('services.yml');
         $loader->load('form_types.yml');
         $loader->load('importexport.yml');
+        $loader->load('twig_extension.yml');
 
         $container->setParameter('oro_address', $config);
     }

--- a/src/Oro/Bundle/AddressBundle/Resources/config/twig_extension.yml
+++ b/src/Oro/Bundle/AddressBundle/Resources/config/twig_extension.yml
@@ -1,0 +1,10 @@
+parameters:
+    oro_address.twig.extension.phone.class: Oro\Bundle\AddressBundle\Twig\PhoneExtension
+
+services:
+    oro_address.twig.extension.phone:
+        class: %oro_address.twig.extension.phone.class%
+        arguments:
+            - @oro_address.provider.phone
+        tags:
+            - { name: twig.extension }

--- a/src/Oro/Bundle/AddressBundle/Tests/Unit/Twig/PhoneExtensionTest.php
+++ b/src/Oro/Bundle/AddressBundle/Tests/Unit/Twig/PhoneExtensionTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Oro\Bundle\AddressBundle\Tests\Unit\Twig;
+
+use Oro\Bundle\AddressBundle\Twig\PhoneExtension;
+use Oro\Bundle\AddressBundle\Provider\PhoneProvider;
+
+class PhoneExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \PHPUnit_Framework_MockObject_MockObject|PhoneProvider */
+    protected $provider;
+
+    /** @var PhoneExtension */
+    protected $extension;
+
+    protected function setUp()
+    {
+        $this->provider = $this->getMockBuilder('Oro\Bundle\AddressBundle\Provider\PhoneProvider')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->extension = new PhoneExtension($this->provider);
+    }
+
+    public function testGetFunctions()
+    {
+        $tests = [
+            'phone_number'  => '\Twig_Function_Method',
+            'phone_numbers' => '\Twig_Function_Method',
+        ];
+
+        $functions = $this->extension->getFunctions();
+
+        $this->assertCount(count($tests), $functions);
+
+        foreach ($tests as $test => $func) {
+            $this->assertArrayHasKey($test, $functions);
+            $this->assertInstanceOf($func, $functions[$test]);
+        }
+    }
+
+    /**
+     * @param int   $expected
+     * @param mixed $expected
+     * @param mixed $obj
+     *
+     * @dataProvider getPhoneNumberProvider
+     */
+    public function testGetPhoneNumber($expectedCalls, $expected, $obj)
+    {
+        $this->provider->expects($this->exactly($expectedCalls))
+            ->method('getPhoneNumber')
+            ->with($obj)
+            ->willReturn('phoneByProvider');
+
+        $this->assertEquals($expected, $this->extension->getPhoneNumber($obj));
+    }
+
+    /**
+     * @param int   $expected
+     * @param mixed $expected
+     * @param mixed $obj
+     *
+     * @dataProvider getPhoneNumberProvider
+     */
+    public function testGetPhoneNumbers($expectedCalls, $expected, $obj)
+    {
+        $this->provider->expects($this->exactly($expectedCalls))
+            ->method('getPhoneNumbers')
+            ->with($obj)
+            ->willReturn('phoneByProvider');
+
+        $this->assertEquals($expected, $this->extension->getPhoneNumbers($obj));
+    }
+
+    /**
+     * @return array
+     */
+    public function getPhoneNumberProvider()
+    {
+        $tests = [];
+
+        $tests['empty object'] = [
+            0,
+            null,
+            null,
+        ];
+
+        $tests['phoneByProvider'] = [
+            1,
+            'phoneByProvider',
+            new \stdClass(),
+        ];
+
+        return $tests;
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals('oro_phone_extension', $this->extension->getName());
+    }
+}

--- a/src/Oro/Bundle/AddressBundle/Twig/PhoneExtension.php
+++ b/src/Oro/Bundle/AddressBundle/Twig/PhoneExtension.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Oro\Bundle\AddressBundle\Twig;
+
+use Oro\Bundle\AddressBundle\Provider\PhoneProvider;
+
+class PhoneExtension extends \Twig_Extension
+{
+    /** @var PhoneProvider */
+    protected $provider;
+
+    /**
+     * @param PhoneProvider $provider
+     */
+    public function __construct(PhoneProvider $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return array An array of functions
+     */
+    public function getFunctions()
+    {
+        return [
+            'phone_number'  => new \Twig_Function_Method($this, 'getPhoneNumber'),
+            'phone_numbers' => new \Twig_Function_Method($this, 'getPhoneNumbers'),
+        ];
+    }
+
+    /**
+     * @param object $obj
+     *
+     * @return string
+     */
+    public function getPhoneNumber($obj)
+    {
+        if (!$obj) {
+            return null;
+        }
+
+        return $this->provider->getPhoneNumber($obj);
+    }
+
+    /**
+     * @param object $obj
+     *
+     * @return string
+     */
+    public function getPhoneNumbers($obj)
+    {
+        if (!$obj) {
+            return null;
+        }
+
+        return $this->provider->getPhoneNumbers($obj);
+    }
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'oro_phone_extension';
+    }
+}


### PR DESCRIPTION
You can get the phone number through the twig function. e.g: `phone_number(entity)`
The phone number is provided by the already implemented `PhoneProvider`.