### PR TITLE
IterableResult: Set whether to use count walker for iterator count

### DIFF
--- a/src/Oro/Bundle/DataGridBundle/Datasource/Orm/IterableResult.php
+++ b/src/Oro/Bundle/DataGridBundle/Datasource/Orm/IterableResult.php
@@ -29,10 +29,11 @@ class IterableResult extends BufferedQueryResultIterator implements IterableResu
      * Constructor
      *
      * @param QueryBuilder|Query $source
+     * @param null|bool $useCountWalker
      */
-    public function __construct($source)
+    public function __construct($source, $useCountWalker = null)
     {
-        parent::__construct($source);
+        parent::__construct($source, $useCountWalker);
         $this->source = $source;
     }
 


### PR DESCRIPTION
Can get the following error:

```
Cannot count query that uses a HAVING clause. Use the output walkers for pagination
```

This can happen when attempting to iterate over a query containing a `HAVING` clause. Allowing the user to set that a count walker shouldn't be used to get a count, the error won't happen.

Seen when performing a bulk action on a datagrid with a filter enabled that has the `filter_by_having` property set to `true`.