### PR TITLE
Remove hardcoded default to UTC timezone

### DIFF
--- a/src/Oro/Bundle/LocaleBundle/Tests/Unit/Twig/DateTimeExtensionTest.php
+++ b/src/Oro/Bundle/LocaleBundle/Tests/Unit/Twig/DateTimeExtensionTest.php
@@ -102,7 +102,7 @@ class DateTimeExtensionTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->formatter->expects($this->once())->method('formatDate')
-            ->with($value, $dateType, $locale, $timeZone ?: 'UTC')
+            ->with($value, $dateType, $locale, $timeZone)
             ->will($this->returnValue($expected));
 
         $this->assertEquals($expected, $this->extension->formatDate($value, $options));
@@ -139,7 +139,7 @@ class DateTimeExtensionTest extends \PHPUnit_Framework_TestCase
         $options = ['locale' => $locale];
 
         $this->formatter->expects($this->once())->method('formatDay')
-            ->with($value, $dateType, $locale, $timeZone ?: 'UTC')
+            ->with($value, $dateType, $locale, $timeZone)
             ->will($this->returnValue($expected));
 
         $this->assertEquals($expected, $this->extension->formatDay($value, $options));
@@ -182,7 +182,7 @@ class DateTimeExtensionTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->formatter->expects($this->once())->method('formatTime')
-            ->with($value, $timeType, $locale, $timeZone ?: 'UTC')
+            ->with($value, $timeType, $locale, $timeZone)
             ->will($this->returnValue($expected));
 
         $this->assertEquals($expected, $this->extension->formatTime($value, $options));

--- a/src/Oro/Bundle/LocaleBundle/Twig/DateTimeExtension.php
+++ b/src/Oro/Bundle/LocaleBundle/Twig/DateTimeExtension.php
@@ -91,7 +91,7 @@ class DateTimeExtension extends \Twig_Extension
     {
         $dateType = $this->getOption($options, 'dateType');
         $locale = $this->getOption($options, 'locale');
-        $timeZone = $this->getOption($options, 'timeZone', 'UTC');
+        $timeZone = $this->getOption($options, 'timeZone');
 
         return $this->formatter->formatDate($date, $dateType, $locale, $timeZone);
     }
@@ -113,7 +113,7 @@ class DateTimeExtension extends \Twig_Extension
     {
         $dateType = $this->getOption($options, 'dateType');
         $locale = $this->getOption($options, 'locale');
-        $timeZone = $this->getOption($options, 'timeZone', 'UTC');
+        $timeZone = $this->getOption($options, 'timeZone');
 
         return $this->formatter->formatDay($date, $dateType, $locale, $timeZone);
     }
@@ -136,7 +136,7 @@ class DateTimeExtension extends \Twig_Extension
     {
         $timeType = $this->getOption($options, 'timeType');
         $locale = $this->getOption($options, 'locale');
-        $timeZone = $this->getOption($options, 'timeZone', 'UTC');
+        $timeZone = $this->getOption($options, 'timeZone');
 
         return $this->formatter->formatTime($date, $timeType, $locale, $timeZone);
     }


### PR DESCRIPTION
This was causing inaccurate date/time display in the MyEmails datagrid because the twig template is not set up by default to pass a timezone option and this code was set to force the timezone to UTC if there was no timezone option passed in.

Fixes #444 