### PR TITLE
Removal of deprecated templating node for asset configuration

### DIFF
--- a/src/Oro/Bundle/NavigationBundle/Resources/config/oro/app.yml
+++ b/src/Oro/Bundle/NavigationBundle/Resources/config/oro/app.yml
@@ -1,5 +1,5 @@
 framework:
-    templating:
+    assets:
         packages:
             routing:
                 version: %assets_version%


### PR DESCRIPTION
The configuration for asset versions and packages etc has been from the framework.templating node to the framework.assets node. The framework.templating node for asset configuration is deprecated
in Symfony 2.7 and will be removed in 3.0.

The current code still functions because the framework bundle just converts the templating node to the assets node: https://github.com/symfony/symfony/blob/2.7/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php#L80