### PR TITLE
Permit the value "Zero" as key in an enum array

### DIFF
--- a/src/Oro/Bundle/EntityExtendBundle/Entity/Repository/EnumValueRepository.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Entity/Repository/EnumValueRepository.php
@@ -32,7 +32,7 @@ class EnumValueRepository extends EntityRepository
         if (strlen($name) === 0) {
             throw new \InvalidArgumentException('$name must not be empty.');
         }
-        if (!isset($id)) {
+        if (!isset($id) || $id === '') {
             $id = ExtendHelper::buildEnumValueId($name);
         } elseif (strlen($id) > ExtendHelper::MAX_ENUM_VALUE_ID_LENGTH) {
             throw new \InvalidArgumentException(

--- a/src/Oro/Bundle/EntityExtendBundle/Entity/Repository/EnumValueRepository.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Entity/Repository/EnumValueRepository.php
@@ -32,7 +32,7 @@ class EnumValueRepository extends EntityRepository
         if (strlen($name) === 0) {
             throw new \InvalidArgumentException('$name must not be empty.');
         }
-        if (empty($id)) {
+        if (!isset($id)) {
             $id = ExtendHelper::buildEnumValueId($name);
         } elseif (strlen($id) > ExtendHelper::MAX_ENUM_VALUE_ID_LENGTH) {
             throw new \InvalidArgumentException(

--- a/src/Oro/Bundle/EntityExtendBundle/Tests/Unit/Entity/Repository/EnumValueRepositoryTest.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Tests/Unit/Entity/Repository/EnumValueRepositoryTest.php
@@ -92,4 +92,15 @@ class EnumValueRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $result->getPriority());
         $this->assertTrue($result->isDefault());
     }
+
+    public function testCreateEnumValueWithEmptyString()
+    {
+        $result = $this->repo->createEnumValue('Test Value 1', 1, true, '');
+
+        $this->assertInstanceOf(self::ENUM_VALUE_CLASS_NAME, $result);
+        $this->assertEquals('test_value_1' , $result->getId());
+        $this->assertEquals('Test Value 1', $result->getName());
+        $this->assertEquals(1, $result->getPriority());
+        $this->assertTrue($result->isDefault());
+    }
 }

--- a/src/Oro/Bundle/EntityExtendBundle/Tests/Unit/Entity/Repository/EnumValueRepositoryTest.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Tests/Unit/Entity/Repository/EnumValueRepositoryTest.php
@@ -98,7 +98,7 @@ class EnumValueRepositoryTest extends \PHPUnit_Framework_TestCase
         $result = $this->repo->createEnumValue('Test Value 1', 1, true, '');
 
         $this->assertInstanceOf(self::ENUM_VALUE_CLASS_NAME, $result);
-        $this->assertEquals('test_value_1' , $result->getId());
+        $this->assertEquals('test_value_1', $result->getId());
         $this->assertEquals('Test Value 1', $result->getName());
         $this->assertEquals(1, $result->getPriority());
         $this->assertTrue($result->isDefault());

--- a/src/Oro/Bundle/EntityExtendBundle/Tests/Unit/Entity/Repository/EnumValueRepositoryTest.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Tests/Unit/Entity/Repository/EnumValueRepositoryTest.php
@@ -87,7 +87,7 @@ class EnumValueRepositoryTest extends \PHPUnit_Framework_TestCase
         $result = $this->repo->createEnumValue('Test Value 1', 1, true, '0');
 
         $this->assertInstanceOf(self::ENUM_VALUE_CLASS_NAME, $result);
-        $this->assertSame('0' , $result->getId());
+        $this->assertSame('0', $result->getId());
         $this->assertEquals('Test Value 1', $result->getName());
         $this->assertEquals(1, $result->getPriority());
         $this->assertTrue($result->isDefault());

--- a/src/Oro/Bundle/EntityExtendBundle/Tests/Unit/Entity/Repository/EnumValueRepositoryTest.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Tests/Unit/Entity/Repository/EnumValueRepositoryTest.php
@@ -81,4 +81,15 @@ class EnumValueRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $result->getPriority());
         $this->assertTrue($result->isDefault());
     }
+
+    public function testCreateEnumValueWithZeroAsKey()
+    {
+        $result = $this->repo->createEnumValue('Test Value 1', 1, true, '0');
+
+        $this->assertInstanceOf(self::ENUM_VALUE_CLASS_NAME, $result);
+        $this->assertSame('0' , $result->getId());
+        $this->assertEquals('Test Value 1', $result->getName());
+        $this->assertEquals(1, $result->getPriority());
+        $this->assertTrue($result->isDefault());
+    }
 }


### PR DESCRIPTION
Currently, if we put a zero as a key in enums arrays, the key is set as equal to the value. 
But, we might need to have a zero as a key/id.

So, by changing the empty() by !isset, we can set the value "0" as an id.

I also included a unit test.