### PR TITLE
Fixed a small bug that was forcing the owner field of an entity to b…

### DIFF
--- a/src/Oro/Bundle/UIBundle/Resources/views/macros.html.twig
+++ b/src/Oro/Bundle/UIBundle/Resources/views/macros.html.twig
@@ -856,10 +856,10 @@
             {% set owner = oro_get_entity_owner(entity) %}
             {% if owner %}
                 {% if (ownerType == 'USER') %}
-                    {% set ownerPath = path('oro_user_view', {'id': entity.owner.id}) %}
+                    {% set ownerPath = path('oro_user_view', {'id': owner.id}) %}
                     {% set ownerName = owner|oro_format_name %}
                 {% elseif (ownerType == 'BUSINESS_UNIT') %}
-                    {% set ownerPath = path('oro_business_unit_view', {'id': entity.owner.id}) %}
+                    {% set ownerPath = path('oro_business_unit_view', {'id': owner.id}) %}
                     {% set ownerName = owner.name %}
                 {% elseif (ownerType == 'ORGANIZATION') %}
                     {% set ownerName = owner.name %}

--- a/src/Oro/Bundle/UIBundle/Resources/views/macros.html.twig
+++ b/src/Oro/Bundle/UIBundle/Resources/views/macros.html.twig
@@ -868,7 +868,7 @@
                     {% if renderLabel %}
                         {{ oro_field_config_value(oro_class_name(entity), 'owner', 'label')|trans }}:
                     {% endif %}
-                    {% if ownerPath is defined and resource_granted('VIEW', entity.owner) %}
+                    {% if ownerPath is defined and resource_granted('VIEW', owner) %}
                         <a href="{{ ownerPath }}">{{ ownerName }}</a>
                     {% else %}
                         {{ ownerName }}


### PR DESCRIPTION
Fixed a small bug that was forcing the owner field of an entity to be named "owner". 
Bellow you can check my config

 ```
* @Config(
 *      defaultValues={
 *          "ownership"={
 *              "owner_type"="BUSINESS_UNIT",
 *              "owner_field_name"="businessUnitOwner",
 *              "owner_column_name"="businessunit_owner_id",
 *              "organization_field_name"="organization",
 *              "organization_column_name"="organization_id"
 *          },
 *          "security"={
 *              "type"="ACL",
 *              "group_name"=""
 *          }
 *      }
 * )
```