### PR TITLE
Fixed bug in dashboard widget config

### DIFF
--- a/src/Oro/Bundle/DashboardBundle/Model/WidgetConfigs.php
+++ b/src/Oro/Bundle/DashboardBundle/Model/WidgetConfigs.php
@@ -227,7 +227,10 @@ class WidgetConfigs
             return new WidgetOptionBag($this->widgetOptionsById[$widgetId]);
         }
 
-        $widget       = $this->findWidget($widgetId);
+        $widget = $this->findWidget($widgetId);
+        if (!$widget) {
+            return new WidgetOptionBag();
+        }
         $widgetConfig = $this->configProvider->getWidgetConfig($widget->getName());
         $options      = $widget->getOptions();
 


### PR DESCRIPTION
The bug could lead to a php fatal:

> Call to a member function getName() on null

We now prevent it by checking if a widget with the widget id was found.

Closes #484
