### PR TITLE
Be more verbose about the error during a Delete

### DIFF
--- a/src/Oro/Bundle/DataGridBundle/Resources/public/js/datagrid/action/delete-action.js
+++ b/src/Oro/Bundle/DataGridBundle/Resources/public/js/datagrid/action/delete-action.js
@@ -43,8 +43,21 @@ define([
             this.model.destroy({
                 url: this.getLink(),
                 wait: true,
-                error: function() {
+                error: function(req, resp) {
                     var messageText = __('You do not have permission to perform this action.');
+
+                    if(resp && resp.statusText)
+                    {
+                        messageText = resp.statusText;
+
+                        if(resp.responseText)
+                        {
+                            var respObj = JSON.parse(resp.responseText);
+                            if(respObj && respObj.message)
+                                messageText += respObj.message;
+                        }
+                    }
+
                     messenger.notificationFlashMessage('error', messageText);
                 },
                 success: function() {


### PR DESCRIPTION
Fixes #486 

When a Ajax DELETE request return a `500`, 

![image](https://cloud.githubusercontent.com/assets/794449/16571190/95633a7e-4224-11e6-8a71-e2d3530224bf.png)

The error handler assumes that the permision was denied.
![image](https://cloud.githubusercontent.com/assets/794449/16571178/517f1a62-4224-11e6-8e7a-f03a77546a59.png)


This PR changes the default message to display the message provided by the API

![image](https://cloud.githubusercontent.com/assets/794449/16571564/a97bbcb8-422c-11e6-9cd8-37ef1ba3d3e7.png)
