### PR TITLE
Add missing (but used) object property

### DIFF
--- a/src/Oro/Component/Config/Loader/FolderContentCumulativeLoader.php
+++ b/src/Oro/Component/Config/Loader/FolderContentCumulativeLoader.php
@@ -66,6 +66,9 @@ class FolderContentCumulativeLoader implements CumulativeResourceLoader
     /** @var PropertyAccess */
     protected $propertyAccessor;
 
+    /** @var string */
+    protected $resource;
+
     /**
      * @param string   $relativeFolderPath
      * @param int      $maxNestingLevel      Pass -1 to unlimit, if you want to find files in exact path given pass 1


### PR DESCRIPTION
The property `resource` is missing in `FolderContentCumulativeLoader`.
Added the property because it is used within the object