### PR TITLE
Upgraded Doctrine ORM to 2.5.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-xml": "*",
         "symfony/symfony": "2.7.*",
         "twig/twig": "1.20.0",
-        "doctrine/orm": "2.5.1",
+        "doctrine/orm": "2.5.4",
         "doctrine/doctrine-bundle": "~1.6.0",
         "doctrine/dbal": "2.5.1",
         "doctrine/data-fixtures": "1.1.1",


### PR DESCRIPTION
The current Doctrine ORM version (2.5.1) doesn't work with PHP 7 type hints, it was fixed in the version 2.5.3.

[DDC-4019: Proxy generator is not including PHP7 return type hints](https://github.com/doctrine/doctrine2/issues/4884)
