### PR TITLE
Rest delete handler react to Database exceptions

### DIFF
--- a/src/Oro/Bundle/SoapBundle/Controller/Api/Rest/RestController.php
+++ b/src/Oro/Bundle/SoapBundle/Controller/Api/Rest/RestController.php
@@ -109,6 +109,8 @@ abstract class RestController extends RestGetController implements
             $view = $this->view(null, Codes::HTTP_NOT_FOUND);
         } catch (ForbiddenException $forbiddenEx) {
             $view = $this->view(['reason' => $forbiddenEx->getReason()], Codes::HTTP_FORBIDDEN);
+        } catch (PDOException $ex) {
+            $view = $this->view(['reason' => $ex->getMessage()], Codes::HTTP_INTERNAL_SERVER_ERROR);
         }
 
         return $this->buildResponse($view, self::ACTION_DELETE, ['id' => $id, 'success' => $isProcessed]);

--- a/src/Oro/Bundle/SoapBundle/Controller/Api/Rest/RestController.php
+++ b/src/Oro/Bundle/SoapBundle/Controller/Api/Rest/RestController.php
@@ -3,6 +3,7 @@
 namespace Oro\Bundle\SoapBundle\Controller\Api\Rest;
 
 use Doctrine\ORM\EntityNotFoundException;
+use Doctrine\DBAL\Driver\PDOException;
 
 use FOS\RestBundle\Util\Codes;
 


### PR DESCRIPTION
Deleting entities from the database may raise many PDO related exceptions like foreign key violation exception. This should be handled in this level to prevent success messages being shown on frontend popups
