### PR TITLE
Fixed v1_13\OroCalendarBundle migration

### DIFF
--- a/src/Oro/Bundle/CalendarBundle/Migrations/Schema/v1_13/OroCalendarBundle.php
+++ b/src/Oro/Bundle/CalendarBundle/Migrations/Schema/v1_13/OroCalendarBundle.php
@@ -33,11 +33,10 @@ class OroCalendarBundle implements Migration, ExtendExtensionAwareInterface
          * If migration is already completed it should not run again
          * ( for case of upgrade from 1.9)
          */
-        if ($schema->hasTable('oro_calendar_event_attendee')) {
-            return;
+        if (!$schema->hasTable('oro_calendar_event_attendee')) {
+            $this->createAttendee($schema);
         }
 
-        $this->createAttendee($schema);
         $this->createRecurrenceTable($schema);
 
         $this->addEnums($schema);


### PR DESCRIPTION
The migration missed to run migrations because it stopped working if the
table `oro_calendar_event_attendee` exists.

But it should only skip to create the table itself. The other parts
should be done.
