### PR TITLE
OroEntityExtendBundle::checkConfig() Process error sent to stdout

### DIFF
--- a/src/Oro/Bundle/EntityExtendBundle/OroEntityExtendBundle.php
+++ b/src/Oro/Bundle/EntityExtendBundle/OroEntityExtendBundle.php
@@ -122,7 +122,10 @@ class OroEntityExtendBundle extends Bundle
                 $process = $pb->getProcess();
                 $exitStatusCode = $process->run();
                 if ($exitStatusCode) {
-                    throw new \RuntimeException($process->getErrorOutput());
+                    if(empty($output))  {
+                        $output = $process->getOutput();
+                    }
+                    throw new \RuntimeException($output);
                 }
 
                 return;

--- a/src/Oro/Bundle/EntityExtendBundle/OroEntityExtendBundle.php
+++ b/src/Oro/Bundle/EntityExtendBundle/OroEntityExtendBundle.php
@@ -122,7 +122,7 @@ class OroEntityExtendBundle extends Bundle
                 $process = $pb->getProcess();
                 $exitStatusCode = $process->run();
                 if ($exitStatusCode) {
-                    if (empty($output))  {
+                    if (empty($output)) {
                         $output = $process->getOutput();
                     }
                     throw new \RuntimeException($output);

--- a/src/Oro/Bundle/EntityExtendBundle/OroEntityExtendBundle.php
+++ b/src/Oro/Bundle/EntityExtendBundle/OroEntityExtendBundle.php
@@ -122,7 +122,7 @@ class OroEntityExtendBundle extends Bundle
                 $process = $pb->getProcess();
                 $exitStatusCode = $process->run();
                 if ($exitStatusCode) {
-                    if(empty($output))  {
+                    if (empty($output))  {
                         $output = $process->getOutput();
                     }
                     throw new \RuntimeException($output);

--- a/src/Oro/Bundle/EntityExtendBundle/OroEntityExtendBundle.php
+++ b/src/Oro/Bundle/EntityExtendBundle/OroEntityExtendBundle.php
@@ -122,6 +122,8 @@ class OroEntityExtendBundle extends Bundle
                 $process = $pb->getProcess();
                 $exitStatusCode = $process->run();
                 if ($exitStatusCode) {
+                    $output = $process->getErrorOutput();
+                    
                     if (empty($output)) {
                         $output = $process->getOutput();
                     }


### PR DESCRIPTION
Hello Oro Team,

When an exception occur during `oro:entity-extend:cache:check` the message is sent to `stdout` and not `stderr`

![image](https://cloud.githubusercontent.com/assets/794449/19292392/c5a05c90-8fe9-11e6-9c9e-bf0a5ec0edae.png)

![image](https://cloud.githubusercontent.com/assets/794449/19292436/07c0fa3a-8fea-11e6-8da3-d4924377c471.png)

Have a good day,
Samuel
