### PR TITLE
Added direct @service qb support to datagrids configuration

### DIFF
--- a/src/Oro/Bundle/DataGridBundle/Datasource/Orm/Configs/YamlProcessor.php
+++ b/src/Oro/Bundle/DataGridBundle/Datasource/Orm/Configs/YamlProcessor.php
@@ -37,7 +37,8 @@ class YamlProcessor implements ConfigProcessorInterface
             } else {
                 throw new DatasourceException(
                     sprintf(
-                        'Datagrid configured with service must return an instance of Doctrine\ORM\QueryBuilder, %s given',
+                        '%s configured with service must return an instance of Doctrine\ORM\QueryBuilder, %s given',
+                        get_class($this),
                         is_object($qb) ? get_class($qb) : gettype($qb)
                     )
                 );

--- a/src/Oro/Bundle/DataGridBundle/Datasource/Orm/Configs/YamlProcessor.php
+++ b/src/Oro/Bundle/DataGridBundle/Datasource/Orm/Configs/YamlProcessor.php
@@ -30,6 +30,18 @@ class YamlProcessor implements ConfigProcessorInterface
             $queryConfig = $config['query'];
             $converter = new YamlConverter();
             return $converter->parse(['query' => $queryConfig], $this->registry);
+        } elseif (array_key_exists('service', $config)) {
+            $qb = $config['service']; // '@service.name->getDatagridQb()'
+            if ($qb instanceof QueryBuilder) {
+                return $qb;
+            } else {
+                throw new DatasourceException(
+                    sprintf(
+                        'Datagrid configured with service must return an instance of Doctrine\ORM\QueryBuilder, %s given',
+                        is_object($qb) ? get_class($qb) : gettype($qb)
+                    )
+                );
+            }
         } elseif (array_key_exists('entity', $config) && array_key_exists('repository_method', $config)) {
             $entity = $config['entity'];
             $method = $config['repository_method'];

--- a/src/Oro/Bundle/DataGridBundle/Datasource/Orm/Configs/YamlProcessor.php
+++ b/src/Oro/Bundle/DataGridBundle/Datasource/Orm/Configs/YamlProcessor.php
@@ -30,8 +30,8 @@ class YamlProcessor implements ConfigProcessorInterface
             $queryConfig = $config['query'];
             $converter = new YamlConverter();
             return $converter->parse(['query' => $queryConfig], $this->registry);
-        } elseif (array_key_exists('service', $config)) {
-            $qb = $config['service']; // '@service.name->getDatagridQb()'
+        } elseif (array_key_exists('query_builder', $config)) {
+            $qb = $config['query_builder']; // '@service.name->getDatagridQb()'
             if ($qb instanceof QueryBuilder) {
                 return $qb;
             } else {

--- a/src/Oro/Bundle/DataGridBundle/Resources/doc/backend/datagrid.md
+++ b/src/Oro/Bundle/DataGridBundle/Resources/doc/backend/datagrid.md
@@ -41,7 +41,7 @@ datagrids:
 
 ####Datasource as service
 Other than the `query` yaml-oriented provider, ORM datasource supports an alternative `query_builder` service-oriented provider. 
-Basically it is possible to use any arbitrary method that returns a valid `Doctrine\ORM\QueryBuilderQueryBuilder` instance.
+Basically it is possible to use any arbitrary method that returns a valid `Doctrine\ORM\QueryBuilder` instance.
 
 ``` php
 // @acme_demo.user.repository

--- a/src/Oro/Bundle/DataGridBundle/Resources/doc/backend/datagrid.md
+++ b/src/Oro/Bundle/DataGridBundle/Resources/doc/backend/datagrid.md
@@ -39,6 +39,43 @@ datagrids:
                 ....   # some query configuration
 ```
 
+####Datasource as service
+Other than the `query` yaml-oriented provider, ORM datasource supports an alternative `query_builder` service-oriented provider. 
+Basically it is possible to use any arbitrary method that returns a valid `Doctrine\ORM\QueryBuilderQueryBuilder` instance.
+
+``` php
+// @acme_demo.user.repository
+public class UserRepository 
+{
+    // ....
+
+    /**
+    * @return Doctrine\ORM\QueryBuilder
+    */
+    public function getUsersQb()
+    {
+        return $this->em->createQueryBuilder()
+            ->from('AcmeDemoBundle:User', 'u')
+            ->select('u')
+            // ->where(...)
+            // ->join(...)
+            // ->orderBy(...)
+        ;
+    }
+}
+
+``` 
+
+In the datagrid configuration just provide the service and method name:
+
+``` yaml
+datagrids:
+    acme-demo-datagrid:
+        source:
+            type: orm  # datasource type
+            query_builder: '@acme_demo.user.repository->getUsersQb()'
+```
+
 #####Parameters binding
 
 If datasource supports parameters binding, additional option "bind_parameters" can be specified. For example
@@ -59,6 +96,9 @@ datagrids:
             bind_parameters:
                 group_id: groupId
 ```
+
+Parameters binding is also supported while using the `query_builder` notation for the ORM data source. 
+Each binding will call `->setParameter('group_id', group_id)` automatically upon the provided builder. 
 
 [More about parameters binding](./parameter_binding.md).
 

--- a/src/Oro/Bundle/DataGridBundle/Tests/Unit/Datasource/Orm/Configs/YamlProcessorTest.php
+++ b/src/Oro/Bundle/DataGridBundle/Tests/Unit/Datasource/Orm/Configs/YamlProcessorTest.php
@@ -73,6 +73,19 @@ class YamlProcessorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testProcessQueryWithService()
+    {
+        $qb = new QueryBuilder($this->em);
+
+        $configs = [
+            'type' => 'orm',
+            'service' => $qb, // '@service.name->getDatagridQb()'
+        ];
+
+        $queryBuilder = $this->processor->processQuery($configs);
+        $this->assertSame($queryBuilder, $qb);
+    }
+
     // @codingStandardsIgnoreStart
     /**
      * @expectedException \Oro\Bundle\DataGridBundle\Exception\DatasourceException
@@ -137,6 +150,26 @@ class YamlProcessorTest extends \PHPUnit_Framework_TestCase
                 get_class($repo),
                 gettype(null)
             )
+        );
+        $this->processor->processQuery($configs);
+    }
+
+    public function testServicedDoNotReturnQueryBuilderShouldThrowException()
+    {
+        $qb = 'not-a-querybuilder';
+
+        $configs = [
+            'type'              => 'orm',
+            'service'            => $qb,
+        ];
+
+        $this->setExpectedException(
+            'Oro\Bundle\DataGridBundle\Exception\DatasourceException',
+            sprintf(
+                'Datagrid configured with service must return an instance of Doctrine\ORM\QueryBuilder, %s given',
+                gettype($qb)
+            )
+
         );
         $this->processor->processQuery($configs);
     }

--- a/src/Oro/Bundle/DataGridBundle/Tests/Unit/Datasource/Orm/Configs/YamlProcessorTest.php
+++ b/src/Oro/Bundle/DataGridBundle/Tests/Unit/Datasource/Orm/Configs/YamlProcessorTest.php
@@ -166,10 +166,10 @@ class YamlProcessorTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(
             'Oro\Bundle\DataGridBundle\Exception\DatasourceException',
             sprintf(
-                'Datagrid configured with service must return an instance of Doctrine\ORM\QueryBuilder, %s given',
+                '%s configured with service must return an instance of Doctrine\ORM\QueryBuilder, %s given',
+                'Oro\Bundle\DataGridBundle\Datasource\Orm\Configs\YamlProcessor',
                 gettype($qb)
             )
-
         );
         $this->processor->processQuery($configs);
     }

--- a/src/Oro/Bundle/DataGridBundle/Tests/Unit/Datasource/Orm/Configs/YamlProcessorTest.php
+++ b/src/Oro/Bundle/DataGridBundle/Tests/Unit/Datasource/Orm/Configs/YamlProcessorTest.php
@@ -79,7 +79,7 @@ class YamlProcessorTest extends \PHPUnit_Framework_TestCase
 
         $configs = [
             'type' => 'orm',
-            'service' => $qb, // '@service.name->getDatagridQb()'
+            'query_builder' => $qb, // '@service.name->getDatagridQb()'
         ];
 
         $queryBuilder = $this->processor->processQuery($configs);
@@ -159,8 +159,8 @@ class YamlProcessorTest extends \PHPUnit_Framework_TestCase
         $qb = 'not-a-querybuilder';
 
         $configs = [
-            'type'              => 'orm',
-            'service'            => $qb,
+            'type' => 'orm',
+            'query_builder' => $qb,
         ];
 
         $this->setExpectedException(


### PR DESCRIPTION
Not everyone likes to mess-up with query in YAML or the Doctrine getRepository(Entity::class) locator pattern. 

This pull request allows much more flexibility in datagrids configuration.

``` yml
datagrid:
    users-grid:
        source:
            type: orm
            service: '@acme_bundle.users.custom.repository->getUsersQueryBuilder()'

```
