### PR TITLE
Remove redundant service

### DIFF
--- a/src/Oro/Bundle/CalendarBundle/Model/Recurrence.php
+++ b/src/Oro/Bundle/CalendarBundle/Model/Recurrence.php
@@ -72,9 +72,6 @@ class Recurrence
     const DAY_SATURDAY = 'saturday';
     /**#@-*/
 
-    /** @var ValidatorInterface */
-    protected $validator;
-
     /** @var StrategyInterface  */
     protected $recurrenceStrategy;
 
@@ -103,12 +100,10 @@ class Recurrence
     ];
 
     /**
-     * @param ValidatorInterface $validator
      * @param StrategyInterface $recurrenceStrategy
      */
-    public function __construct(ValidatorInterface $validator, StrategyInterface $recurrenceStrategy)
+    public function __construct(StrategyInterface $recurrenceStrategy)
     {
-        $this->validator = $validator;
         $this->recurrenceStrategy = $recurrenceStrategy;
     }
 

--- a/src/Oro/Bundle/CalendarBundle/Resources/config/services.yml
+++ b/src/Oro/Bundle/CalendarBundle/Resources/config/services.yml
@@ -396,7 +396,6 @@ services:
 
     oro_calendar.model.recurrence:
         arguments:
-            - '@validator'
             - '@oro_calendar.recurrence.strategy'
         class: '%oro_calendar.model.recurrence.class%'
 

--- a/src/Oro/Bundle/CalendarBundle/Tests/Unit/Form/Type/CalendarEventApiTypeTest.php
+++ b/src/Oro/Bundle/CalendarBundle/Tests/Unit/Form/Type/CalendarEventApiTypeTest.php
@@ -395,13 +395,10 @@ class CalendarEventApiTypeTest extends TypeTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')
-            ->getMock();
-
         $strategy = $this->getMockBuilder('Oro\Bundle\CalendarBundle\Model\Recurrence\StrategyInterface')
             ->getMock();
 
-        $recurrenceModel = new Recurrence($validator, $strategy);
+        $recurrenceModel = new Recurrence($strategy);
 
         $types = [
             new ReminderCollectionType($this->registry),

--- a/src/Oro/Bundle/CalendarBundle/Tests/Unit/Form/Type/RecurrenceFormTypeTest.php
+++ b/src/Oro/Bundle/CalendarBundle/Tests/Unit/Form/Type/RecurrenceFormTypeTest.php
@@ -17,12 +17,10 @@ class RecurrenceFormTypeTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')
-            ->getMock();
         $strategy = $this->getMockBuilder('Oro\Bundle\CalendarBundle\Model\Recurrence\StrategyInterface')
             ->getMock();
 
-        $this->model = new Recurrence($validator, $strategy);
+        $this->model = new Recurrence($strategy);
         $this->type = new RecurrenceFormType($this->model);
     }
 

--- a/src/Oro/Bundle/CalendarBundle/Tests/Unit/Model/RecurrenceTest.php
+++ b/src/Oro/Bundle/CalendarBundle/Tests/Unit/Model/RecurrenceTest.php
@@ -11,20 +11,14 @@ class RecurrenceTest extends \PHPUnit_Framework_TestCase
     protected $model;
 
     /** @var \PHPUnit_Framework_MockObject_MockObject */
-    protected $validator;
-
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
     protected $strategy;
 
     protected function setUp()
     {
-        $this->validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')
-            ->getMock();
-
         $this->strategy = $this->getMockBuilder('Oro\Bundle\CalendarBundle\Model\Recurrence\StrategyInterface')
             ->getMock();
 
-        $this->model = new Recurrence($this->validator, $this->strategy);
+        $this->model = new Recurrence($this->strategy);
     }
 
     public function testGetOccurrences()

--- a/src/Oro/Bundle/CalendarBundle/Tests/Unit/Twig/RecurrenceExtensionTest.php
+++ b/src/Oro/Bundle/CalendarBundle/Tests/Unit/Twig/RecurrenceExtensionTest.php
@@ -15,9 +15,6 @@ class RecurrenceExtensionTest extends \PHPUnit_Framework_TestCase
     protected $extension;
 
     /** @var \PHPUnit_Framework_MockObject_MockObject */
-    protected $validator;
-
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
     protected $strategy;
 
     /** @var \PHPUnit_Framework_MockObject_MockObject */
@@ -28,11 +25,9 @@ class RecurrenceExtensionTest extends \PHPUnit_Framework_TestCase
         $this->translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')
-            ->getMock();
         $this->strategy = $this->getMockBuilder('Oro\Bundle\CalendarBundle\Model\Recurrence\StrategyInterface')
             ->getMock();
-        $this->recurrenceModel = new Recurrence($this->validator, $this->strategy);
+        $this->recurrenceModel = new Recurrence($this->strategy);
         $this->extension = new RecurrenceExtension($this->translator, $this->recurrenceModel);
     }
 

--- a/src/Oro/Bundle/CalendarBundle/Tests/Unit/Validator/RecurrenceValidatorTest.php
+++ b/src/Oro/Bundle/CalendarBundle/Tests/Unit/Validator/RecurrenceValidatorTest.php
@@ -78,12 +78,10 @@ class RecurrenceValidatorTest extends \PHPUnit_Framework_TestCase
      */
     protected function getValidator()
     {
-        $validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')
-            ->getMock();
         $this->strategy = $this->getMockBuilder('Oro\Bundle\CalendarBundle\Model\Recurrence\StrategyInterface')
             ->getMock();
 
-        $recurrenceModel = new ModelRecurrence($validator, $this->strategy);
+        $recurrenceModel = new ModelRecurrence($this->strategy);
 
         $validator = new RecurrenceValidator($recurrenceModel);
         $validator->initialize($this->context);


### PR DESCRIPTION
I believe the validator service which is being injected into the Recurrence class is not being used.  Therefore it is redundant and can be removed.