### PR TITLE
Fix #547 Add migration to use InnoDB on mysql version 5.6.

### DIFF
--- a/src/Oro/Bundle/SearchBundle/Migrations/Schema/OroSearchBundleInstaller.php
+++ b/src/Oro/Bundle/SearchBundle/Migrations/Schema/OroSearchBundleInstaller.php
@@ -35,7 +35,7 @@ class OroSearchBundleInstaller implements Installation, ContainerAwareInterface,
      */
     public function getMigrationVersion()
     {
-        return 'v1_1';
+        return 'v1_2';
     }
 
     /**

--- a/src/Oro/Bundle/SearchBundle/Migrations/Schema/v1_2/OroSearchBundle.php
+++ b/src/Oro/Bundle/SearchBundle/Migrations/Schema/v1_2/OroSearchBundle.php
@@ -4,48 +4,16 @@ namespace Oro\Bundle\SearchBundle\Migrations\Schema\v1_2;
 
 use Doctrine\DBAL\Schema\Schema;
 
-use Doctrine\ORM\EntityManager;
 use Oro\Bundle\MigrationBundle\Migration\Migration;
 use Oro\Bundle\MigrationBundle\Migration\QueryBag;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class OroSearchBundle implements Migration , ContainerAwareInterface
+class OroSearchBundle implements Migration
 {
-    /**
-     * @var ContainerInterface
-     */
-    protected $container;
-
-
-    /**
-     * @inheritdoc
-     */
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
     public function up(Schema $schema, QueryBag $queries)
     {
-        //save old avatars to new place
-        /** @var EntityManager $em */
-        $em         = $this->container->get('doctrine.orm.entity_manager');
-
-        $driverName = $em->getConnection()->getDriver()->getName() ;
-
-        if(in_array($driverName , array( 'pdo_mysql' ,'mysqli' ))) {
-
-            $query      = "show variables like \"version\"";
-            $version = $em->getConnection()->executeQuery($query)->fetchColumn(1);
-
-            if(version_compare($version , '5.6.0' , '>=')) {
-                $queries->addQuery('ALTER TABLE `oro_search_index_text` ENGINE = INNODB;');
-            }
-        }
-
+        $queries->addQuery(new OroSearchBundleUseInnoDB());
     }
 }

--- a/src/Oro/Bundle/SearchBundle/Migrations/Schema/v1_2/OroSearchBundle.php
+++ b/src/Oro/Bundle/SearchBundle/Migrations/Schema/v1_2/OroSearchBundle.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Oro\Bundle\SearchBundle\Migrations\Schema\v1_2;
+
+use Doctrine\DBAL\Schema\Schema;
+
+use Doctrine\ORM\EntityManager;
+use Oro\Bundle\MigrationBundle\Migration\Migration;
+use Oro\Bundle\MigrationBundle\Migration\QueryBag;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class OroSearchBundle implements Migration , ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+
+    /**
+     * @inheritdoc
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function up(Schema $schema, QueryBag $queries)
+    {
+        //save old avatars to new place
+        /** @var EntityManager $em */
+        $em         = $this->container->get('doctrine.orm.entity_manager');
+
+        $driverName = $em->getConnection()->getDriver()->getName() ;
+
+        if(in_array($driverName , array( 'pdo_mysql' ,'mysqli' ))) {
+
+            $query      = "show variables like \"version\"";
+            $version = $em->getConnection()->executeQuery($query)->fetchColumn(1);
+
+            if(version_compare($version , '5.6.0' , '>=')) {
+                $queries->addQuery('ALTER TABLE `oro_search_index_text` ENGINE = INNODB;');
+            }
+        }
+
+    }
+}

--- a/src/Oro/Bundle/SearchBundle/Migrations/Schema/v1_2/OroSearchBundleUseInnoDB.php
+++ b/src/Oro/Bundle/SearchBundle/Migrations/Schema/v1_2/OroSearchBundleUseInnoDB.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Oro\Bundle\SearchBundle\Migrations\Schema\v1_2;
+
+use Doctrine\DBAL\Connection;
+use Oro\Bundle\MigrationBundle\Migration\ConnectionAwareInterface;
+use Oro\Bundle\MigrationBundle\Migration\MigrationQuery;
+use Psr\Log\LoggerInterface;
+
+class OroSearchBundleUseInnoDB implements MigrationQuery , ConnectionAwareInterface
+{
+    /**
+     * @var Connection
+     */
+    protected $connection;
+
+    /**
+     * @inheritdoc
+     */
+    public function setConnection(Connection $connection )
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * Gets a query description
+     * If this query has several sub queries you can return an array of descriptions for each sub query
+     *
+     * @return string|string[]
+     */
+    public function getDescription()
+    {
+        return "Use InnoDB for Mysql >= 5.6";
+    }
+
+    /**
+     * Executes a query
+     *
+     * @param LoggerInterface $logger A logger which can be used to log details of an execution process
+     */
+    public function execute(LoggerInterface $logger)
+    {
+        $driverName = $this->connection->getDriver()->getName();
+
+        if(in_array($driverName , array( 'pdo_mysql' ,'mysqli' ))) {
+
+            $version = $this->connection->executeQuery('show variables like "version"')->fetchColumn(1);
+
+            if(version_compare($version , '5.6.0' , '>=')) {
+                $query = 'ALTER TABLE `oro_search_index_text` ENGINE = INNODB;';
+                $logger->info($query);
+                $this->connection->executeQuery($query);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
OroSearch use MySAM schema that is incompatible with MySQL GTID / Replication