### PR TITLE
Added  ability to import  yaml configuration  files recursively

### DIFF
--- a/src/Oro/Component/Config/Loader/YamlCumulativeFileLoader.php
+++ b/src/Oro/Component/Config/Loader/YamlCumulativeFileLoader.php
@@ -31,20 +31,20 @@ class YamlCumulativeFileLoader extends CumulativeFileLoader
 
             if (array_key_exists('imports', $configData) && is_array($configData['imports'])) {
                 if (empty($importedPaths)) {
-                    $importedPaths[] = $file; // for checking circular own-import
+                    $importedPaths[] = $file; // for checking circular self-import
                 }
 
+                $parent = new \SplFileInfo($file);
                 $imports = $configData['imports'];
                 unset($configData['imports']);
 
                 foreach ($imports as $importData) {
                     if (array_key_exists('resource', $importData)) {
-                        $parent = new \SplFileInfo($file);
                         $import = new \SplFileInfo($parent->getPath() . DIRECTORY_SEPARATOR . $importData['resource']);
                         $importPath = $import->getRealPath();
 
                         if (in_array($importPath, $importedPaths, true)) {
-                            $importedPaths[] = $importPath; // for a complete tree in the message
+                            $importedPaths[] = $importPath; // for a complete tree in the exception message
 
                             throw new \InvalidArgumentException(
                                 sprintf('Circular import detected in for "%s".', implode(' >> ', $importedPaths))

--- a/src/Oro/Component/Config/Loader/YamlCumulativeFileLoader.php
+++ b/src/Oro/Component/Config/Loader/YamlCumulativeFileLoader.php
@@ -19,14 +19,14 @@ class YamlCumulativeFileLoader extends CumulativeFileLoader
     /**
      * Parses a YAML file.
      *
-     * @param string $filePath Path to a file
+     * @param string $file Path to a file
      * @return array|null
      * @throws \InvalidArgumentException When loading of YAML file returns error
      */
-    protected function parseFile($filePath)
+    protected function parseFile($file)
     {
         try {
-            $configData = Yaml::parse(file_get_contents($filePath)) ? : [];
+            $configData = Yaml::parse(file_get_contents($file)) ? : [];
 
             if (array_key_exists('imports', $configData) && is_array($configData['imports'])) {
                 $imports = $configData['imports'];
@@ -34,8 +34,8 @@ class YamlCumulativeFileLoader extends CumulativeFileLoader
 
                 foreach ($imports as $importData) {
                     if (array_key_exists('resource', $importData)) {
-                        $file = new \SplFileInfo($filePath);
-                        $import = new \SplFileInfo($file->getPath() . DIRECTORY_SEPARATOR . $importData['resource']);
+                        $info = new \SplFileInfo($file);
+                        $import = new \SplFileInfo($info->getPath() . DIRECTORY_SEPARATOR . $importData['resource']);
                         $configData = array_merge_recursive($configData, $this->parseFile($import));
                     }
                 }
@@ -43,8 +43,8 @@ class YamlCumulativeFileLoader extends CumulativeFileLoader
 
             return $configData;
         } catch (ParseException $e) {
-            $e->setParsedFile($filePath);
-            throw new \InvalidArgumentException(sprintf('Unable to parse file "%s".', $filePath), $e->getCode(), $e);
+            $e->setParsedFile($file);
+            throw new \InvalidArgumentException(sprintf('Unable to parse file "%s".', $file), $e->getCode(), $e);
         }
     }
 }

--- a/src/Oro/Component/Config/Loader/YamlCumulativeFileLoader.php
+++ b/src/Oro/Component/Config/Loader/YamlCumulativeFileLoader.php
@@ -3,8 +3,9 @@
 namespace Oro\Component\Config\Loader;
 
 use Symfony\Component\Yaml\Exception\ParseException;
-use Symfony\Component\Yaml\Parser as YamlParser;
+use Symfony\Component\Yaml\Yaml;
 
+// TODO: Override CumulativeFileLoader::isResourceFresh to check also imported files
 class YamlCumulativeFileLoader extends CumulativeFileLoader
 {
     /**
@@ -18,18 +19,32 @@ class YamlCumulativeFileLoader extends CumulativeFileLoader
     /**
      * Parses a YAML file.
      *
-     * @param string $file Path to a file
+     * @param string $filePath Path to a file
      * @return array|null
      * @throws \InvalidArgumentException When loading of YAML file returns error
      */
-    protected function parseFile($file)
+    protected function parseFile($filePath)
     {
-        $yamlParser = new YamlParser();
         try {
-            return $yamlParser->parse(file_get_contents($file));
+            $configData = Yaml::parse(file_get_contents($filePath)) ? : [];
+
+            if (array_key_exists('imports', $configData) && is_array($configData['imports'])) {
+                $imports = $configData['imports'];
+                unset($configData['imports']);
+
+                foreach ($imports as $importData) {
+                    if (array_key_exists('resource', $importData)) {
+                        $file = new \SplFileInfo($filePath);
+                        $import = new \SplFileInfo($file->getPath() . DIRECTORY_SEPARATOR . $importData['resource']);
+                        $configData = array_merge_recursive($configData, $this->parseFile($import));
+                    }
+                }
+            }
+
+            return $configData;
         } catch (ParseException $e) {
-            $e->setParsedFile($file);
-            throw new \InvalidArgumentException(sprintf('Unable to parse file "%s".', $file), $e->getCode(), $e);
+            $e->setParsedFile($filePath);
+            throw new \InvalidArgumentException(sprintf('Unable to parse file "%s".', $filePath), $e->getCode(), $e);
         }
     }
 }

--- a/src/Oro/Component/Config/Loader/YamlCumulativeFileLoader.php
+++ b/src/Oro/Component/Config/Loader/YamlCumulativeFileLoader.php
@@ -20,10 +20,11 @@ class YamlCumulativeFileLoader extends CumulativeFileLoader
      * Parses a YAML file.
      *
      * @param string $file Path to a file
+     * @param string[] $parsedPaths already parsed paths
      * @return array|null
      * @throws \InvalidArgumentException When loading of YAML file returns error
      */
-    protected function parseFile($file)
+    protected function parseFile($file, $parsedPaths = [])
     {
         try {
             $configData = Yaml::parse(file_get_contents($file)) ? : [];
@@ -36,7 +37,13 @@ class YamlCumulativeFileLoader extends CumulativeFileLoader
                     if (array_key_exists('resource', $importData)) {
                         $info = new \SplFileInfo($file);
                         $import = new \SplFileInfo($info->getPath() . DIRECTORY_SEPARATOR . $importData['resource']);
-                        $configData = array_merge_recursive($configData, $this->parseFile($import));
+
+                        if (in_array($import->getRealPath(), $parsedPaths, true)) {
+                            throw new \InvalidArgumentException('Circular import detected in ' . $file);
+                        }
+
+                        $parsedPaths[] = $import->getRealPath();
+                        $configData = array_merge_recursive($configData, $this->parseFile($import, $parsedPaths));
                     }
                 }
             }

--- a/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/import/parent.yml
+++ b/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/import/parent.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: 'sub/child1.yml' }

--- a/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/import/sub/child1.yml
+++ b/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/import/sub/child1.yml
@@ -1,0 +1,1 @@
+test: success

--- a/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/import/sub/child1.yml
+++ b/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/import/sub/child1.yml
@@ -1,1 +1,2 @@
-test: success
+imports:
+    - { resource: 'child2.yml' }

--- a/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/import/sub/child2.yml
+++ b/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/import/sub/child2.yml
@@ -1,0 +1,1 @@
+test: success

--- a/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/loop/parent.yml
+++ b/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/loop/parent.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: 'sub/child1.yml' }

--- a/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/loop/sub/child1.yml
+++ b/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/loop/sub/child1.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: 'child2.yml' }

--- a/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/loop/sub/child2.yml
+++ b/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/loop/sub/child2.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: 'child1.yml' }

--- a/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/loop/sub/child2.yml
+++ b/src/Oro/Component/Config/Tests/Unit/Fixtures/Bundle/TestBundle1/Resources/config/loop/sub/child2.yml
@@ -1,2 +1,2 @@
 imports:
-    - { resource: 'child1.yml' }
+    - { resource: '..\parent.yml' }

--- a/src/Oro/Component/Config/Tests/Unit/Loader/CumulativeConfigLoaderTest.php
+++ b/src/Oro/Component/Config/Tests/Unit/Loader/CumulativeConfigLoaderTest.php
@@ -277,4 +277,18 @@ class CumulativeConfigLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([$resource1], $result);
     }
+
+    public function testYamlCumulativeFileLoaderImports()
+    {
+        $bundle1      = new TestBundle1();
+        $bundleClass = get_class($bundle1);
+        $bundleDir   = dirname((new \ReflectionClass($bundle1))->getFileName());
+
+        $resourceLoader1 = new YamlCumulativeFileLoader('Resources/config/import/parent.yml');
+        $resource = $resourceLoader1->load($bundleClass, $bundleDir);
+
+        $this->assertArrayNotHasKey('imports', $resource->data); // import must be transparent
+        $this->assertArrayHasKey('test', $resource->data);
+        $this->assertEquals($resource->data['test'], 'success');
+    }
 }

--- a/src/Oro/Component/Config/Tests/Unit/Loader/CumulativeConfigLoaderTest.php
+++ b/src/Oro/Component/Config/Tests/Unit/Loader/CumulativeConfigLoaderTest.php
@@ -302,6 +302,5 @@ class CumulativeConfigLoaderTest extends \PHPUnit_Framework_TestCase
 
         $resourceLoader1 = new YamlCumulativeFileLoader('Resources/config/loop/parent.yml');
         $resourceLoader1->load($bundleClass, $bundleDir);
-
     }
 }

--- a/src/Oro/Component/Config/Tests/Unit/Loader/CumulativeConfigLoaderTest.php
+++ b/src/Oro/Component/Config/Tests/Unit/Loader/CumulativeConfigLoaderTest.php
@@ -291,4 +291,17 @@ class CumulativeConfigLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('test', $resource->data);
         $this->assertEquals($resource->data['test'], 'success');
     }
+
+    public function testYamlCumulativeFileLoaderImportsInfiniteLoop()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+
+        $bundle1      = new TestBundle1();
+        $bundleClass = get_class($bundle1);
+        $bundleDir   = dirname((new \ReflectionClass($bundle1))->getFileName());
+
+        $resourceLoader1 = new YamlCumulativeFileLoader('Resources/config/loop/parent.yml');
+        $resourceLoader1->load($bundleClass, $bundleDir);
+
+    }
 }


### PR DESCRIPTION
Hello there,
Related to #492.

This merge request allows to import recursively 'yml' config files using the standard Symfony notation for imports in yaml:

```php
# Resources/config/datagrid.yml

imports:
    - { resource: 'datagrid/user-grid.yml' }
    - { resource: 'datagrid/manager-grid.yml' }
    - { resource: 'datagrid/administrator-grid.yml' }
```

Note:

1. It works with any file loaded by a `YamlCumulativeFileLoader`
   - datagrid.yml
   - app.yml
   - navigation.yml
   - and so on....
2. An imported file can in turn import too, recursively.
3. Autocomplete for resources works too (with the PHPStorm plugin)
4. The change is "configuration agnostic" and should be compatible with any ORO version (1.10, 2.0). 
5. It is tested and I also added a Unit( @mkudelya  but I I do not have the time to update the docs right now :) )

