### PR TITLE
PHP 7.1 Fix Unit Tests that assumes DateTime() Microseconds is always 0

### DIFF
--- a/src/Oro/Bundle/AddressBundle/Tests/Unit/Entity/AbstractAddressTest.php
+++ b/src/Oro/Bundle/AddressBundle/Tests/Unit/Entity/AbstractAddressTest.php
@@ -68,7 +68,7 @@ class AbstractAddressTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($address->getCreated());
         $this->assertNotNull($address->getUpdated());
 
-        $this->assertEquals($address->getCreated(), $address->getUpdated());
+        $this->assertEquals($address->getCreated(), $address->getUpdated() , '' , 1);
     }
 
     public function testGetRegionName()

--- a/src/Oro/Bundle/EmailBundle/Tests/Unit/Entity/EmailBodyTest.php
+++ b/src/Oro/Bundle/EmailBundle/Tests/Unit/Entity/EmailBodyTest.php
@@ -66,7 +66,7 @@ class EmailBodyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(false, $entity->getBodyIsText());
         $this->assertEquals(false, $entity->getHasAttachments());
         $this->assertEquals(false, $entity->getPersistent());
-        $this->assertGreaterThanOrEqual($createdAt, $entity->getCreated());
+        $this->assertGreaterThanOrEqual($entity->getCreated(), $createdAt);
     }
 
     public function testTextBodyGetterAndSetter()

--- a/src/Oro/Bundle/EmailBundle/Tests/Unit/Entity/EmailTest.php
+++ b/src/Oro/Bundle/EmailBundle/Tests/Unit/Entity/EmailTest.php
@@ -102,7 +102,7 @@ class EmailTest extends \PHPUnit_Framework_TestCase
         $createdAt = new \DateTime('now', new \DateTimeZone('UTC'));
 
         $this->assertEquals(Email::NORMAL_IMPORTANCE, $entity->getImportance());
-        $this->assertGreaterThanOrEqual($createdAt, $entity->getCreated());
+        $this->assertGreaterThanOrEqual($entity->getCreated(), $createdAt);
     }
 
     public function testIsHeadGetterAndSetter()

--- a/src/Oro/Bundle/EmailBundle/Tests/Unit/Entity/EmailThreadTest.php
+++ b/src/Oro/Bundle/EmailBundle/Tests/Unit/Entity/EmailThreadTest.php
@@ -32,7 +32,7 @@ class EmailThreadTest extends \PHPUnit_Framework_TestCase
         $createdAt = new \DateTime('now', new \DateTimeZone('UTC'));
 
         $this->assertEquals(Email::NORMAL_IMPORTANCE, $entity->getImportance());
-        $this->assertGreaterThanOrEqual($createdAt, $entity->getCreated());
+        $this->assertGreaterThanOrEqual($entity->getCreated(), $createdAt);
     }
 
     /**

--- a/src/Oro/Bundle/ImapBundle/Tests/Unit/Form/Type/ChoiceAccountTypeTest.php
+++ b/src/Oro/Bundle/ImapBundle/Tests/Unit/Form/Type/ChoiceAccountTypeTest.php
@@ -160,6 +160,7 @@ class ChoiceAccountTypeTest extends FormIntegrationTestCase
      */
     public function setDataProvider()
     {
+        $tokenDateTime = new \DateTime();
         return [
             'should have only accountType field' => [
                 [
@@ -188,7 +189,7 @@ class ChoiceAccountTypeTest extends FormIntegrationTestCase
                         'imapHost' => '',
                         'imapPort' => '',
                         'imapEncryption' => '',
-                        'accessTokenExpiresAt' => new \DateTime(),
+                        'accessTokenExpiresAt' => $tokenDateTime ,
                         'accessToken' => 'token',
                         'googleAuthCode' => 'googleAuthCode'
                     ],
@@ -197,7 +198,7 @@ class ChoiceAccountTypeTest extends FormIntegrationTestCase
                     'accountType' => 'gmail',
                     'userEmailOrigin' => $this->getUserEmailOrigin([
                         'user' => 'test',
-                        'accessTokenExpiresAt' => new \DateTime(),
+                        'accessTokenExpiresAt' => $tokenDateTime ,
                         'googleAuthCode' => 'googleAuthCode',
                         'accessToken' => 'token',
                     ])
@@ -206,7 +207,7 @@ class ChoiceAccountTypeTest extends FormIntegrationTestCase
                     'accountType' => 'gmail',
                     'userEmailOrigin' => $this->getUserEmailOrigin([
                         'user' => 'test',
-                        'accessTokenExpiresAt' => new \DateTime(),
+                        'accessTokenExpiresAt' => $tokenDateTime ,
                         'googleAuthCode' => 'googleAuthCode',
                         'accessToken' => 'token'
                     ])
@@ -220,7 +221,7 @@ class ChoiceAccountTypeTest extends FormIntegrationTestCase
                         'imapHost' => '',
                         'imapPort' => '',
                         'imapEncryption' => '',
-                        'accessTokenExpiresAt' => new \DateTime(),
+                        'accessTokenExpiresAt' => $tokenDateTime ,
                         'accessToken' => '',
                         'googleAuthCode' => 'googleAuthCode',
                         'password' => '111'

--- a/src/Oro/Bundle/ImapBundle/Tests/Unit/Form/Type/ConfigurationGmailTypeTest.php
+++ b/src/Oro/Bundle/ImapBundle/Tests/Unit/Form/Type/ConfigurationGmailTypeTest.php
@@ -141,6 +141,8 @@ class ConfigurationGmailTypeTest extends FormIntegrationTestCase
      */
     public function setDataProvider()
     {
+        $tokenDateTime = new \DateTime();
+
         return [
             'should bind correct data' => [
                 [
@@ -151,7 +153,7 @@ class ConfigurationGmailTypeTest extends FormIntegrationTestCase
                     'smtpHost' => 'smtp.gmail.com',
                     'smtpPort' => '993',
                     'smtpEncryption' => 'ssl',
-                    'accessTokenExpiresAt' => new \DateTime(),
+                    'accessTokenExpiresAt' => $tokenDateTime ,
                     'accessToken' => '1',
                     'refreshToken' => '111'
                 ],
@@ -163,7 +165,7 @@ class ConfigurationGmailTypeTest extends FormIntegrationTestCase
                     'smtpHost' => 'smtp.gmail.com',
                     'smtpPort' => '993',
                     'smtpEncryption' => 'ssl',
-                    'accessTokenExpiresAt' => new \DateTime(),
+                    'accessTokenExpiresAt' => $tokenDateTime ,
                     'accessToken' => '1',
                     'refreshToken' => '111'
                 ],
@@ -175,7 +177,7 @@ class ConfigurationGmailTypeTest extends FormIntegrationTestCase
                     'smtpHost' => 'smtp.gmail.com',
                     'smtpPort' => '993',
                     'smtpEncryption' => 'ssl',
-                    'accessTokenExpiresAt' => new \DateTime(),
+                    'accessTokenExpiresAt' => $tokenDateTime ,
                     'accessToken' => '1',
                     'refreshToken' => '111'
                 ],

--- a/src/Oro/Bundle/NotificationBundle/Tests/Unit/EventListener/MassNotificationListenerTest.php
+++ b/src/Oro/Bundle/NotificationBundle/Tests/Unit/EventListener/MassNotificationListenerTest.php
@@ -64,7 +64,7 @@ class MassNotificationListenerTest extends \PHPUnit_Framework_TestCase
                 $this->assertEquals($logEntity->getSender(), 'test <from@test.com>');
                 $this->assertEquals($logEntity->getSubject(), 'test subject');
                 $this->assertEquals($logEntity->getBody(), 'test body');
-                $this->assertEquals($logEntity->getScheduledAt(), $date);
+                $this->assertEquals($logEntity->getScheduledAt(), $date , '' , 1);
                 $this->assertEquals($logEntity->getStatus(), MassNotification::STATUS_SUCCESS);
 
                 return true;


### PR DESCRIPTION
Related to #600 


In PHP 7.1 DateTime constructor incorporates microseconds, this generate errors in tests. 
http://php.net/manual/en/migration71.incompatible.php
