### PR TITLE
Performance improvement : Only refresh cache during the main request

### DIFF
--- a/src/Oro/Bundle/SecurityBundle/Annotation/AclListener.php
+++ b/src/Oro/Bundle/SecurityBundle/Annotation/AclListener.php
@@ -39,6 +39,9 @@ class AclListener
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
+        if(!$event->isMasterRequest())
+            return;
+        
         if (!$this->isFresh()) {
             $this->cacheProvider->warmUpCache();
             $this->dumper->dump();


### PR DESCRIPTION
Hi!

Looking at the profiler, it seems that the AclListener unserialize and check cache validity for **all requests and sub-requests**   in dev environement

During our investigation, this fix allow a 15% to 30% speed improvement. depending on the page. 

For example, the AclListener is loaded  17 times in sub-requests X  14 ms  = **238 ms** 
![image](https://cloud.githubusercontent.com/assets/794449/21560768/d131a056-ce31-11e6-8789-0a952e1ef499.png)

From our side, this seems like a bug, since on all sub-requests, no new data is reloaded since timestamps match.. Before merging, please ensure that this fix doesnt have side-effects of some kind. We dont know  Oro Platform internals :) 

Thanks,
Samuel
