### PR TITLE
Fix for #527

### DIFF
--- a/src/Oro/Bundle/AttachmentBundle/Tests/Unit/Validator/ConfigFileValidatorTest.php
+++ b/src/Oro/Bundle/AttachmentBundle/Tests/Unit/Validator/ConfigFileValidatorTest.php
@@ -96,4 +96,50 @@ class ConfigFileValidatorTest extends \PHPUnit_Framework_TestCase
         $result = $this->configValidator->validate($file, $dataClass, $fieldName);
         $this->assertSame($violationList, $result);
     }
+    
+    public function testValidateWithEmptyFieldName()
+    {
+        $dataClass = 'testClass';
+        $file = new ComponentFile(
+            realpath(__DIR__ . '/../Fixtures/testFile/test.txt')
+        );
+        $fieldName = '';
+        $mimeTypes = "image/*\ntext/plain";
+        $maxsize = 1; // 1Mb
+
+        $entityAttachmentConfig = $this->getMockBuilder('Oro\Bundle\EntityConfigBundle\Config\Config')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->attachmentConfigProvider->expects($this->once())
+            ->method('getConfig')
+            ->with($dataClass)
+            ->will($this->returnValue($entityAttachmentConfig));
+        $entityAttachmentConfig->expects($this->any())
+            ->method('get')
+            ->willReturnOnConsecutiveCalls(false, $maxsize);
+        $this->config->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnOnConsecutiveCalls('', $mimeTypes);
+
+        $violationList = $this->getMockBuilder('Symfony\Component\Validator\ConstraintViolationList')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->validator->expects($this->once())
+            ->method('validate')
+            ->with(
+                $this->identicalTo($file),
+                [
+                    new FileConstraint(
+                        [
+                            'maxSize'   => $maxsize * 1024 * 1024,
+                            'mimeTypes' => explode("\n", $mimeTypes)
+                        ]
+                    )
+                ]
+            )
+            ->willReturn($violationList);
+
+        $result = $this->configValidator->validate($file, $dataClass, $fieldName);
+        $this->assertSame($violationList, $result);
+    }
 }

--- a/src/Oro/Bundle/AttachmentBundle/Validator/ConfigFileValidator.php
+++ b/src/Oro/Bundle/AttachmentBundle/Validator/ConfigFileValidator.php
@@ -94,7 +94,7 @@ class ConfigFileValidator
     {
         $mimeTypes = explode("\n", $mimeString);
         if (count($mimeTypes) === 1 && $mimeTypes[0] === '') {
-            return '';
+            return [];
         }
 
         return $mimeTypes;


### PR DESCRIPTION
Adds a unit test that forces `getMimeArray` function to return early.  This unit test shows that `getMimeArray` must return an empty array rather than an empty string.  

`getMimeArray` updated to return an empty array if it returns early