### PR TITLE
Refactored AbstractAddress::__toString

### DIFF
--- a/src/Oro/Bundle/AddressBundle/Entity/AbstractAddress.php
+++ b/src/Oro/Bundle/AddressBundle/Entity/AbstractAddress.php
@@ -794,9 +794,7 @@ abstract class AbstractAddress implements EmptyItem, FullNameInterface, AddressI
             $this->getPostalCode(),
         );
 
-        $str = implode(' ', $data);
-        $check = trim(str_replace(',', '', $str));
-        return empty($check) ? '' : $str;
+        return trim(implode(' ', $data), " \t\n\r\0\x0B,");
     }
 
     /**

--- a/src/Oro/Bundle/AddressBundle/Tests/Unit/Entity/AbstractAddressTest.php
+++ b/src/Oro/Bundle/AddressBundle/Tests/Unit/Entity/AbstractAddressTest.php
@@ -208,7 +208,29 @@ class AbstractAddressTest extends \PHPUnit_Framework_TestCase
                     'country' => $this->createMockCountry('Ukraine'),
                 ),
                 'FirstName LastName , Street   some region , Ukraine 12345'
-            )
+            ),
+            array(
+                array(
+                    'firstName' => '',
+                    'lastName' => 'LastName',
+                    'street' => 'Street',
+                    'region' => $this->createMockRegion('some region'),
+                    'postalCode' => '',
+                    'country' => $this->createMockCountry('Ukraine'),
+                ),
+                'LastName , Street   some region , Ukraine'
+            ),
+            array(
+                array(
+                    'firstName' => '',
+                    'lastName' => '',
+                    'street' => '',
+                    'region' => '',
+                    'postalCode' => '',
+                    'country' => '',
+                ),
+                ''
+            ),
         );
     }
 


### PR DESCRIPTION
- Extended the unit tests for AbstractAddress::__toString()
- Enhanced readability for method
  - Removed strange str_replace
  - Removed strange $check

Results in faster method and clearer code.

Successor of #566 because rebased on master.
