### PR TITLE
Add tooltip for segment type in segments edit form

### DIFF
--- a/src/Oro/Bundle/SegmentBundle/Form/Type/SegmentType.php
+++ b/src/Oro/Bundle/SegmentBundle/Form/Type/SegmentType.php
@@ -24,7 +24,8 @@ class SegmentType extends AbstractQueryDesignerType
                     'class'       => 'OroSegmentBundle:SegmentType',
                     'property'    => 'label',
                     'required'    => true,
-                    'empty_value' => 'oro.segment.form.choose_segment_type'
+                    'empty_value' => 'oro.segment.form.choose_segment_type',
+                    'tooltip'     => 'oro.segment.type.tooltip_text'
                 ]
             )
             ->add('description', 'textarea', ['required' => false]);

--- a/src/Oro/Bundle/SegmentBundle/Resources/translations/messages.en.yml
+++ b/src/Oro/Bundle/SegmentBundle/Resources/translations/messages.en.yml
@@ -25,6 +25,9 @@ oro:
             dynamic: Dynamic
             label:   Type
             static:  Manual
+            tooltip_text: >
+              "Dynamic" segments are updated as soon as any changes have taken place in the system.
+              "Manual" segments will be updated only following the user request in the View page of the Segment record.
 
         form:
             choose_segment_type:    Choose segment type

--- a/src/Oro/Bundle/SegmentBundle/Tests/Unit/Form/Type/SegmentTypeTest.php
+++ b/src/Oro/Bundle/SegmentBundle/Tests/Unit/Form/Type/SegmentTypeTest.php
@@ -49,7 +49,8 @@ class SegmentTypeTest extends \PHPUnit_Framework_TestCase
                     'class'       => 'OroSegmentBundle:SegmentType',
                     'property'    => 'label',
                     'required'    => true,
-                    'empty_value' => 'oro.segment.form.choose_segment_type'
+                    'empty_value' => 'oro.segment.form.choose_segment_type',
+                    'tooltip'     => 'oro.segment.type.tooltip_text'
                 ]
             )
             ->will($this->returnSelf());


### PR DESCRIPTION
Since the segmentation type isn't self-explaining it is useful to have a tooltip that describes the difference between dynamic and static segments.