### PR TITLE
Changed error message on the frontend block types

### DIFF
--- a/src/Oro/Component/Layout/Block/Type/Options.php
+++ b/src/Oro/Component/Layout/Block/Type/Options.php
@@ -31,7 +31,7 @@ class Options implements \ArrayAccess, \Iterator
             $option = $this->options[$offset];
             if ($shouldBeEvaluated && $option instanceof Expression) {
                 throw new \InvalidArgumentException(
-                    sprintf('Option "%s" should be evaluated but expression now.', $offset)
+                    sprintf('Option "%s" value should be evaluated. It is currently an ExpressionLanguage component object.', $offset)
                 );
             }
             return $option;


### PR DESCRIPTION
This message was not very clear about the error, it seemed to me as a bad grammar until I understood it was talking about Symfony's ExpressionLanguage component.