### PR TITLE
Workflow: Fix the WorkflowTransitionCronTriggerTopic

### DIFF
--- a/src/Oro/Bundle/WorkflowBundle/Async/Topic/AbstractWorkflowTransitionTriggerTopic.php
+++ b/src/Oro/Bundle/WorkflowBundle/Async/Topic/AbstractWorkflowTransitionTriggerTopic.php
@@ -22,6 +22,6 @@ abstract class AbstractWorkflowTransitionTriggerTopic extends AbstractTopic
 
         $resolver
             ->setRequired(TransitionTriggerMessage::MAIN_ENTITY)
-            ->setAllowedTypes(TransitionTriggerMessage::MAIN_ENTITY, ['int', 'string', 'array']);
+            ->setAllowedTypes(TransitionTriggerMessage::MAIN_ENTITY, ['int', 'string', 'array', 'null']);
     }
 }


### PR DESCRIPTION
The HandleTransitionCronTriggerCommand pushes a message with an invalid body to the queue.
The mainEntity parameter is always null in the command, but was not set as an allowed type.