### PR TITLE
Implement ACL support in PermissionsHandler

### DIFF
--- a/src/Oro/Bundle/InstallerBundle/Composer/PermissionsHandler.php
+++ b/src/Oro/Bundle/InstallerBundle/Composer/PermissionsHandler.php
@@ -27,15 +27,115 @@ class PermissionsHandler
      */
     public function setPermissions($directory)
     {
+        // Check ACL support before attempting to use it
+        if (!$this->isAclSupported()) {
+            return $this->setPermissionsTraditional($directory);
+        }
+
         try {
             $this->setPermissionsSetfacl($directory);
             $this->setPermissionsChmod($directory);
 
             return true;
         } catch (ProcessFailedException $exception) {
+            // Fall back to traditional permissions if ACL fails
+            return $this->setPermissionsTraditional($directory);
+        }
+    }
+
+    /**
+     * Check if ACL is supported on the filesystem
+     *
+     * @return bool
+     */
+    protected function isAclSupported(): bool
+    {
+        static $aclSupported = null;
+
+        if ($aclSupported !== null) {
+            return $aclSupported;
         }
 
-        return false;
+        $fs = new Filesystem();
+        $testDir = 'var/cache';
+        if (!$fs->exists($testDir)) {
+            $fs->mkdir($testDir, 0755);
+        }
+
+        $testFile = $testDir . '/.acl_test_' . uniqid();
+
+        try {
+            $fs->touch($testFile);
+            $user = trim(shell_exec('whoami') ?: 'www-data');
+
+            $testCmd = sprintf('setfacl -m "u:%s:rw" %s 2>&1', escapeshellarg($user), escapeshellarg($testFile));
+            $process = $this->getProcess($testCmd);
+            $process->setTimeout(2);
+            $process->run();
+
+            if ($process->isSuccessful()) {
+                $aclSupported = true;
+            } else {
+                $output = $process->getErrorOutput() . $process->getOutput();
+                $aclSupported = stripos($output, 'Operation not supported') === false
+                    && stripos($output, 'not supported') === false;
+            }
+
+            if ($fs->exists($testFile)) {
+                $fs->remove($testFile);
+            }
+        } catch (\Exception $e) {
+            $aclSupported = false;
+            if ($fs->exists($testFile)) {
+                try {
+                    $fs->remove($testFile);
+                } catch (\Exception $e2) {
+                    // Ignore cleanup errors
+                }
+            }
+        }
+
+        return $aclSupported;
+    }
+
+    /**
+     * Set permissions using traditional Unix chmod/chown when ACL is not supported
+     *
+     * @param string $directory
+     * @return bool
+     */
+    protected function setPermissionsTraditional($directory): bool
+    {
+        $fs = new Filesystem();
+        if (!$fs->exists($directory)) {
+            $fs->mkdir($directory);
+        }
+
+        try {
+            $user = trim(shell_exec('whoami') ?: 'www-data');
+            $group = $user;
+
+            $webServerUser = $this->runProcessQuiet(self::PS_AUX);
+            if ($webServerUser) {
+                $group = $webServerUser;
+            }
+
+            $chownCmd = sprintf('chown -R %s:%s %s', escapeshellarg($user), escapeshellarg($group), escapeshellarg($directory));
+            $process = $this->getProcess($chownCmd);
+            $process->run();
+
+            $chmodCmd = sprintf('find %s -type d -exec chmod 775 {} +', escapeshellarg($directory));
+            $process = $this->getProcess($chmodCmd);
+            $process->run();
+
+            $chmodCmd = sprintf('find %s -type f -exec chmod 664 {} +', escapeshellarg($directory));
+            $process = $this->getProcess($chmodCmd);
+            $process->run();
+
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
     /**
@@ -44,6 +144,10 @@ class PermissionsHandler
      */
     public function setPermissionsSetfacl($path)
     {
+        if (!$this->isAclSupported()) {
+            throw new ProcessFailedException(new Process(['setfacl'], null, null, null, 0));
+        }
+
         $fs = new Filesystem();
         if (!$fs->exists($path)) {
             $fs->mkdir($path);
@@ -68,9 +172,14 @@ class PermissionsHandler
         }
 
         foreach ($this->getUsers() as $user) {
-            $this->runProcess(
-                str_replace([self::VAR_USER, self::VAR_PATH], [$user, $path], self::CHMOD)
-            );
+            try {
+                $this->runProcess(
+                    str_replace([self::VAR_USER, self::VAR_PATH], [$user, $path], self::CHMOD)
+                );
+            } catch (ProcessFailedException $e) {
+                // chmod +a might not be supported, skip it
+                continue;
+            }
         }
     }
 
@@ -104,6 +213,21 @@ class PermissionsHandler
         return trim($process->getOutput());
     }
 
+    /**
+     * Run process without throwing exception on failure
+     *
+     * @param string $commandline
+     * @return string|null
+     */
+    protected function runProcessQuiet($commandline)
+    {
+        try {
+            return $this->runProcess($commandline);
+        } catch (ProcessFailedException $e) {
+            return null;
+        }
+    }
+
     protected function getProcess(string $commandline): Process
     {
         if (method_exists(Process::class, 'fromShellCommandline')) {
@@ -113,3 +237,4 @@ class PermissionsHandler
         }
     }
 }
+


### PR DESCRIPTION
Added ACL support check and fallback to traditional permissions. Improved error handling for permission setting.

On Warden docker environment command "composer install" error : > Oro\Bundle\InstallerBundle\Composer\ScriptHandler::setPermissions Script Oro\Bundle\InstallerBundle\Composer\ScriptHandler::setPermissions handling the set-permissions event terminated with an exception The following exception is caused by a process timeout Check https://getcomposer.org/doc/06-config.md#process-timeout for details

In Process.php line 1205:
                                                                                                                                           
  The process "setfacl -Rm "u:`whoami`:rwX,d:u:`whoami`:rwX,g:`whoami`:rw,d:g:`whoami`:rw" var/cache" exceeded the timeout of 60 seconds.

<img width="1967" height="479" alt="image" src="https://github.com/user-attachments/assets/571e8522-cf97-4342-9422-ba8a60588e75" />

full log: 
```
composer install
Gathering patches from patch file.
No patches supplied.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.
Nothing to install, update or remove
Package behat/transliterator is abandoned, you should avoid using it. No replacement was suggested.
Package box/spout is abandoned, you should avoid using it. No replacement was suggested.
Package doctrine/annotations is abandoned, you should avoid using it. No replacement was suggested.
Package doctrine/cache is abandoned, you should avoid using it. No replacement was suggested.
Package laminas/laminas-loader is abandoned, you should avoid using it. No replacement was suggested.
Package sensio/framework-extra-bundle is abandoned, you should avoid using it. Use Symfony instead.
Generating autoload files
167 packages you are using are looking for funding.
Use the `composer fund` command to find out more!

> Oro\Bundle\InstallerBundle\Composer\ScriptHandler::setPermissions
Script Oro\Bundle\InstallerBundle\Composer\ScriptHandler::setPermissions handling the set-permissions event terminated with an exception
The following exception is caused by a process timeout
Check https://getcomposer.org/doc/06-config.md#process-timeout for details

In Process.php line 1205:
                                                                                                                                           
  The process "setfacl -Rm "u:`whoami`:rwX,d:u:`whoami`:rwX,g:`whoami`:rw,d:g:`whoami`:rw" var/cache" exceeded the timeout of 60 seconds.  
```
