### PR TITLE
Fix implicit nullable parameter deprecation in ScriptHandler

### DIFF
--- a/src/Oro/Bundle/InstallerBundle/Composer/ScriptHandler.php
+++ b/src/Oro/Bundle/InstallerBundle/Composer/ScriptHandler.php
@@ -327,7 +327,7 @@ class ScriptHandler
         }
     }
 
-    private static function runProcess(IOInterface $inputOutput, array $cmd, int $timeout, string $cwd = null): int
+    private static function runProcess(IOInterface $inputOutput, array $cmd, int $timeout, ?string $cwd = null): int
     {
         $inputOutput->write(implode(' ', $cmd));
 


### PR DESCRIPTION
Use explicit nullable type `?string` for the `$cwd` parameter in `runProcess()` to fix PHP 8.4+ deprecation notice:

"Implicitly marking parameter $cwd as nullable is deprecated, the explicit nullable type must be used instead"