### PR TITLE
Remove redundant symfony/polyfill-php70 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,6 @@
         "hwi/oauth-bundle": "2.1.0",
         "kriswallsmith/buzz": "~1.3.0",
         "matomo/device-detector": "~6.0.6",
-        "symfony/polyfill-php70": "1.*",
         "openspout/openspout": "~4.32.0",
         "nette/php-generator": "~4.1.3",
         "brick/math": "~0.11.0",


### PR DESCRIPTION
This package depends on `symfony/polyfill-php70`, but also `php: ~8.5.0`, so the polyfill requirement doesn't seem necessary anymore?