### PR TITLE
Fix nullable return in getUserIdentifier() when username is not set

### DIFF
--- a/src/Oro/Bundle/UserBundle/Entity/AbstractUser.php
+++ b/src/Oro/Bundle/UserBundle/Entity/AbstractUser.php
@@ -142,7 +142,7 @@ abstract class AbstractUser implements
     #[\Override]
     public function getUserIdentifier(): string
     {
-        return $this->username;
+        return $this->username ?? '';
     }
 
     public function setUserIdentifier($username): self


### PR DESCRIPTION
Fixes https://github.com/oroinc/customer-portal/issues/14

## Problem

When importing `CustomerUser` records without an ID (creation) and without an email address, a `TypeError` is triggered during Symfony validation.

The validator calls `__toString()` on the freshly instantiated entity, which internally calls `getUserIdentifier()`:

    public function __toString()
    {
        return (string)$this->getUserIdentifier();
    }

The `(string)` cast never executes. The `TypeError` is raised inside `getUserIdentifier()` itself, before the cast can apply.

## Root cause

`$username` is declared as `?string` at the Doctrine level, which is a valid state during entity construction (e.g. import processing before the field is hydrated). However, Symfony's `UserInterface` contract enforces a strict `string` return type on `getUserIdentifier()`.

## Fix

Return an empty string as fallback to bridge the gap between the nullable Doctrine mapping and the strict Symfony interface contract.