### PR TITLE
Allow pnpm to install packages

### DIFF
--- a/src/Oro/Bundle/InstallerBundle/Composer/ScriptHandler.php
+++ b/src/Oro/Bundle/InstallerBundle/Composer/ScriptHandler.php
@@ -349,7 +349,7 @@ class ScriptHandler
     private static function pnpmCi(IOInterface $inputOutput, int $timeout = 60, bool $verbose = false): void
     {
         $logLevel = $verbose ? 'info' : 'error';
-        $npmCiCmd = ['pnpm', 'install', '--lockfile-only', '--loglevel', $logLevel];
+        $npmCiCmd = ['pnpm', 'install', '--frozen-lockfile', '--loglevel', $logLevel];
 
         if (self::runProcess($inputOutput, $npmCiCmd, $timeout) !== 0) {
             throw new \RuntimeException('Failed to install pnpm assets');


### PR DESCRIPTION
In the transition from npm to pnpm the changeover from running `npm ci` to `pnpm i --lockfile-only` resulted in incorrect behaviour.

The `npm ci` command downloaded and installed packages at the specific versions as specified in the lockfile.

`pnpm i --lockfile-only` on the other hand does not download dependencies, it just updates the lockfile.  This is not a substitute for `npm ci`.

What we want instead of `pnpm i --frozen-lockfile` as this will download and install exactly the dependencies specified in the lock file, which is equivelent to the `npm ci` command.

The problem with using `--lockfile-only` is that when trying to deploy outside of dev or CI environments (`--frozen-lockfile` is by default on in CI) no npm dependencies are downloaded or installed, which results in a broken system.

This patch updates the command line used by the composer helper script accordingly.